### PR TITLE
docs: add module headers and audit report

### DIFF
--- a/App.css.html
+++ b/App.css.html
@@ -1,3 +1,12 @@
+/*
+ * Module: App.css (include)
+ * Rôle: fournit la feuille de styles sombre pour l'ancienne interface HtmlService du CRM.
+ * Entrées publiques: n/a (inclus via include('App.css') dans les vues).
+ * Dépendances: inséré dans un <style> embarqué depuis App.js.html / index.html.
+ * Effets de bord: applique des styles globaux sur body.wrap, formulaires et grilles.
+ * Pièges: rester compatible avec HtmlService (pas de variables CSS dynamiques ni @import).
+ * MAJ: 2025-09-26 – Codex Audit
+ */
 // ==============================
 // FICHIER 4/4 — app.css.html (CSS inline pour HtmlService)
 // ==============================

--- a/App.js.html
+++ b/App.js.html
@@ -1,3 +1,12 @@
+<!--
+  Module: App.js (legacy UI bootstrap)
+  Rôle: gère la navigation de la version historique du CRM et orchestre les appels google.script.run.
+  Entrées publiques: charge loadDashboardData(), loadStockData(), loadSalesData(), loadPurchasesData(), loadAnalyticsData(), saveConfiguration().
+  Dépendances: google.script.run (Ui_Server / CRM_DataService), DOM éléments #kpiList/#stock-table, include('CRM_Scripts').
+  Effets de bord: manipule innerHTML, gère états locaux et verrous réseau.
+  Pièges: éviter les mutations hors promesse, attention aux quotas Apps Script si rafraîchissements répétés.
+  MAJ: 2025-09-26 – Codex Audit
+-->
 <!-- ========================
      FICHIER 5/4 — app.js.html
      JS client pour HtmlService (UI du CRM)

--- a/BackupScriptApi.gs
+++ b/BackupScriptApi.gs
@@ -1,4 +1,13 @@
 /**
+ * Module: BackupScriptApi
+ * Rôle: automatiser la sauvegarde complète d'un projet Apps Script via l'API Script et Drive.
+ * Entrées publiques: backupProjectUsingScriptApi(), scheduleDailyBackupScriptApi().
+ * Dépendances: UrlFetchApp (Script API), ScriptApp (token), DriveApp (dossiers/ZIP), SpreadsheetApp UI (alertes).
+ * Effets de bord: crée des dossiers horodatés, fichiers individuels, ZIP et summary.json; peut mettre à la corbeille d'anciens backups.
+ * Pièges: nécessite activation de l'API Script + scope script.projects, quotas UrlFetch/Drive, valeur TARGET_SCRIPT_ID à renseigner.
+ * MAJ: 2025-09-26 – Codex Audit
+ */
+/**
  * ===== BackupScriptApi.gs =====
  * Sauvegarde 100% du code d'un projet Apps Script via Script API (UrlFetchApp).
  * - Exporte .gs, .html, .json (manifest si récupéré)

--- a/Boosts & Coûts fonctionnement.gs
+++ b/Boosts & Coûts fonctionnement.gs
@@ -1,4 +1,13 @@
 /**
+ * Module: Boosts & Coûts fonctionnement
+ * Rôle: assister la saisie manuelle des boosts marketing et des coûts fixes puis journaliser un résumé mensuel.
+ * Entrées publiques: addBoostPrompt(), addCostPrompt(), logMonthlyCostsAndBoosts().
+ * Dépendances: SpreadsheetApp (feuilles "Boosts", "Coûts fonctionnement", "Logs").
+ * Effets de bord: ouvre des prompts UI, insère des lignes, additionne les montants récents et écrit des logs.
+ * Pièges: prompts bloquants, conversions locales virgule/point, risque de quotas si journalisation fréquente.
+ * MAJ: 2025-09-26 – Codex Audit
+ */
+/**
  * Étape 7 — Boosts & Coûts fonctionnement (v1 simple)
  * - Deux prompts rapides pour ajouter des lignes dans les onglets Boosts / Coûts fonctionnement
  * - Un résumé mensuel (sommes) écrit dans Logs

--- a/Bordereaux_PDF.gs
+++ b/Bordereaux_PDF.gs
@@ -1,4 +1,13 @@
 /**
+ * Module: Bordereaux_PDF
+ * Rôle: générer des étiquettes PDF à partir de l'onglet Bordereaux et des métadonnées stock.
+ * Entrées publiques: labelsGenerateCurrent(), labelsGenerateVisible().
+ * Dépendances: SpreadsheetApp (feuilles "Bordereaux" et "Stock"), SlidesApp (création overlay), DriveApp (export PDF).
+ * Effets de bord: met à jour Statut PDF/Lien dans la feuille, crée des fichiers Slides/PDF et les place sur Drive.
+ * Pièges: quotas Slides/Drive, nettoyage manuel des présentations, dépendance à la colonne SKU pour retrouver le titre.
+ * MAJ: 2025-09-26 – Codex Audit
+ */
+/**
  * Étape 6 — Bordereaux (v1 overlay via Google Slides -> PDF)
  * - Lit l’onglet Bordereaux (colonnes: Date, SKU, Titre (avec SKU), N° suivi, Transporteur, Statut PDF, Lien PDF, Notes)
  * - Produit un PDF A6 (ou A4) avec overlay: Titre+SKU (+ N° suivi), puis renseigne "Statut PDF" et "Lien PDF"

--- a/CRM_Config.html
+++ b/CRM_Config.html
@@ -1,3 +1,12 @@
+<!--
+  Module: CRM_Config.html
+  Rôle: interface de configuration complète (général, plateformes, notifications) affichée dans un modal Sheets.
+  Entrées publiques: actions boutons saveConfiguration(), refreshData(), openQuickAdd() via CRM_Scripts.
+  Dépendances: include('CRM_Styles'), include('CRM_Scripts'), google.script.run.getConfiguration/saveConfiguration/createBackup/exportAllData.
+  Effets de bord: met à jour le DOM, déclenche des appels serveur et montre des états de chargement.
+  Pièges: éviter innerHTML non échappé, recharger les données après sauvegarde pour cohérence, attention aux réponses volumineuses.
+  MAJ: 2025-09-26 – Codex Audit
+-->
 <!DOCTYPE html>
 <html>
 <head>

--- a/CRM_ConfigService.gs
+++ b/CRM_ConfigService.gs
@@ -1,4 +1,13 @@
 /**
+ * Module: CRM_ConfigService
+ * Rôle: exposer CRUD configuration (lecture, sauvegarde, export, backup) pour l'UI.
+ * Entrées publiques: getConfiguration(), saveConfiguration(), getDefaultConfiguration(), createBackup(), exportAllData(), getPlatformCommission(), calculateSaleMargins().
+ * Dépendances: SpreadsheetApp (feuilles via SHEETS_CONFIG), Utilities (horodatage), CRM_DataService helpers (createSheetIfNotExists, flattenConfiguration).
+ * Effets de bord: lit/écrit l'onglet Configuration, crée des classeurs de backup, appelle SpreadsheetApp.create.
+ * Pièges: conversions JSON pour listes, risques de quotas Drive lors de backups, cohérence avec structure SHEETS_CONFIG.
+ * MAJ: 2025-09-26 – Codex Audit
+ */
+/**
  * Service de gestion de la configuration CRM
  */
 

--- a/CRM_DataService.gs
+++ b/CRM_DataService.gs
@@ -1,4 +1,13 @@
 /**
+ * Module: CRM_DataService
+ * Rôle: définir la structure des feuilles et fournir les services de données (stock, ventes, achats, analytics, dashboard).
+ * Entrées publiques: createSheetsStructure(), setupSheetFormats(), getDashboardData(), getStockData(), getSalesData(), getPurchasesData(), getAnalyticsData(), getRecentActivity().
+ * Dépendances: SpreadsheetApp (feuilles Stock/Ventes/Achats/Configuration/Dashboard), log_(), calculateDashboardStats(), autres helpers locaux.
+ * Effets de bord: crée/formatte des feuilles, applique validations et formats, lit massivement les données pour calculer des KPI.
+ * Pièges: nombreuses lectures de plage (penser batching), conversions Number sensibles au format européen, attention aux appels répétés (quotas 6 min).
+ * MAJ: 2025-09-26 – Codex Audit
+ */
+/**
  * Service de gestion des données CRM
  * Toutes les opérations CRUD sur les feuilles Google Sheets
  */

--- a/CRM_Interface.html
+++ b/CRM_Interface.html
@@ -1,3 +1,12 @@
+<!--
+  Module: CRM_Interface.html
+  Rôle: gabarit SPA riche (header, navigation, vues multiples) pour la version complète du CRM.
+  Entrées publiques: boutons déclenchant switchView(), refreshData(), openQuickAdd(), loadDashboardData() depuis CRM_Scripts.
+  Dépendances: include('CRM_Styles'), include('CRM_Scripts'), google.script.run endpoints (voir CRM_Scripts).
+  Effets de bord: structure le DOM, contient placeholders pour tableaux et indicateurs mis à jour dynamiquement.
+  Pièges: veiller à charger CRM_Scripts après le DOM, synchroniser les IDs d'éléments avec les scripts.
+  MAJ: 2025-09-26 – Codex Audit
+-->
 <!DOCTYPE html>
 <html>
 <head>

--- a/CRM_Scripts.html
+++ b/CRM_Scripts.html
@@ -1,3 +1,12 @@
+<!--
+  Module: CRM_Scripts.html
+  Rôle: logique client de l'interface CRM riche (chargement des vues, filtres, analytics).
+  Entrées publiques: initializeApp(), switchView(), loadDashboardData(), loadStockData(), loadSalesData(), loadPurchasesData(), loadAnalyticsData(), saveConfiguration(), createBackup(), exportAllData().
+  Dépendances: google.script.run (getDashboardData, getStockData, getSalesData, getPurchasesData, getAnalyticsData, getConfiguration, saveConfiguration, createBackup, exportAllData), debounce(), formatters locaux.
+  Effets de bord: manipule DOM via innerHTML, gère états globaux, déclenche alertes toast.
+  Pièges: charges réseau multiples (risque quotas), DOM fragile si IDs changent, sanitize nécessaires avant injection HTML.
+  MAJ: 2025-09-26 – Codex Audit
+-->
 <script>
 // Variables globales
 let currentView = 'dashboard';

--- a/CRM_Styles.html
+++ b/CRM_Styles.html
@@ -1,3 +1,12 @@
+<!--
+  Module: CRM_Styles.html
+  Rôle: définir la charte visuelle (couleurs, layout) des écrans CRM modernes.
+  Entrées publiques: n/a (inclus via <?!= include('CRM_Styles'); ?>).
+  Dépendances: appliqué aux composants déclarés dans CRM_Interface.html et CRM_Config.html.
+  Effets de bord: surcharge les styles globaux, définit variables CSS et composants réutilisables.
+  Pièges: reste chargé dans HtmlService (pas de @import externe), surveiller spécificité pour ne pas casser d'autres vues.
+  MAJ: 2025-09-26 – Codex Audit
+-->
 <style>
 /* Variables CSS inspirées de VintedCRM */
 :root {

--- a/Code.gs
+++ b/Code.gs
@@ -1,4 +1,13 @@
 /**
+ * Module: Code
+ * Rôle: point d'entrée Sheets (menu CRM) et helpers HtmlService.
+ * Entrées publiques: onOpen(), openCRM(), openConfig(), include(), initializeStructure().
+ * Dépendances: SpreadsheetApp UI (menus, modales), HtmlService (Index, CRM_Config), createSheetsStructure() depuis CRM_DataService.
+ * Effets de bord: crée un menu personnalisé, ouvre des dialogues modaux, initialises les onglets si demandé.
+ * Pièges: respecter XFrameOptions ALLOWALL pour HtmlService, alerte utilisateur sur erreurs, attention aux appels multiples d'initializeStructure().
+ * MAJ: 2025-09-26 – Codex Audit
+ */
+/**
  * CRM Complet - Point d'entrée principal
  * Inspiré de VintedCRM.com pour l'ergonomie et les couleurs
  */

--- a/Config Advanced.gs
+++ b/Config Advanced.gs
@@ -1,4 +1,13 @@
 /**
+ * Module: Config Advanced
+ * Rôle: helpers de lecture typée des paramètres avancés (commissions multi-plateforme, URSSAF, coûts fixes).
+ * Entrées publiques: cfgAll_(), cfgBool_(), cfgNum_(), getPlatformFees_(), getGlobalFlags_().
+ * Dépendances: getConfig_() (Config.gs) et structure de l'onglet Configuration.
+ * Effets de bord: aucun (lecture pure, conversion).
+ * Pièges: valeurs mal formatées (virgules vs points), prévoir defaults si les clés manquent.
+ * MAJ: 2025-09-26 – Codex Audit
+ */
+/**
  * Étape 8 — Lecture avancée de l'onglet Configuration
  * Clés supportées (exemples):
  *  - COMM_VINTED_PCT, COMM_VINTED_MIN, COMM_VINTED_FLAT

--- a/Config.gs
+++ b/Config.gs
@@ -1,4 +1,13 @@
 /**
+ * Module: Config
+ * Rôle: lecture clé/valeur simple depuis l'onglet Configuration.
+ * Entrées publiques: getConfig_(), cfg_().
+ * Dépendances: SpreadsheetApp (feuille "Configuration").
+ * Effets de bord: aucun (lectures).
+ * Pièges: onglet absent ou vide => renvoie map vide; conversions manuelles nécessaires en aval.
+ * MAJ: 2025-09-26 – Codex Audit
+ */
+/**
  * Lecture simple de la table Configuration (clé/valeur)
  * Ex. clés: GMAIL_LABEL_INGEST_STOCK, GMAIL_LABEL_SALES_VINTED, COMMISSION_VINTED, APPLY_URSSAF...
  */

--- a/Dashboard.gs
+++ b/Dashboard.gs
@@ -1,3 +1,12 @@
+/**
+ * Module: Dashboard
+ * Rôle: générer la feuille Dashboard avec KPI, blocs de données et graphiques.
+ * Entrées publiques: buildDashboard().
+ * Dépendances: SpreadsheetApp (feuilles Dashboard, Ventes, Stock, Boosts, Coûts fonctionnement), computeKPIs_(), buildMonthlyRevenue_(), buildPlatformSplit_().
+ * Effets de bord: efface et réécrit l'onglet Dashboard, crée des charts, lit massivement les données.
+ * Pièges: appels coûteux si feuilles volumineuses (préférer caches), conversions Date/Number, veiller à ne pas supprimer filtres personnalisés.
+ * MAJ: 2025-09-26 – Codex Audit
+ */
 /** Étape 9 — Dashboard : KPI + Graphiques (idempotent) */
 
 function buildDashboard() {

--- a/Gmail_Ingest_Parsers.gs
+++ b/Gmail_Ingest_Parsers.gs
@@ -1,4 +1,13 @@
 /**
+ * Module: Gmail_Ingest_Parsers
+ * Rôle: parseurs d'emails et gestion d'idempotence (Logs + cache d'IDs).
+ * Entrées publiques: alreadyProcessed_(), markProcessed_(), ensureLogsSheet_(), parse* helpers (utilisés par Gmail_Ingest_Run).
+ * Dépendances: GmailApp via consommateurs, SpreadsheetApp (Logs), PropertiesService/CacheService via stateGet_/statePut_.
+ * Effets de bord: écrit dans Logs, stocke des IDs traités dans UserProperties/Cache.
+ * Pièges: gérer la taille du cache (PROC_IDS_MAX_SIZE_), synchronisation retardée des logs, quotas Gmail si boucles trop larges.
+ * MAJ: 2025-09-26 – Codex Audit
+ */
+/**
  * Parseurs d’emails par label.
  * Idempotence: on marque Logs + labels Traite/Erreur pour éviter les doublons.
  * NOTE: pas de variables globales de type SHEET_* ici pour éviter les collisions.

--- a/Gmail_Ingest_Run.gs
+++ b/Gmail_Ingest_Run.gs
@@ -1,4 +1,13 @@
 /**
+ * Module: Gmail_Ingest_Run
+ * Rôle: orchestrer l'ingestion Gmail en version standard (stock JSON, ventes, favoris/offres, achats).
+ * Entrées publiques: ingestAllLabels(), ingestStockJson(), ingestSales(), ingestFavsOffersVinted(), ingestPurchasesVinted().
+ * Dépendances: GmailApp (labels), SpreadsheetApp (Stock, Ventes, Achats), parseurs de Gmail_Ingest_Parsers, getConfig_().
+ * Effets de bord: marque les threads Traite/Erreur, upsert des lignes dans Stock/Ventes/Achats, incrémente compteurs.
+ * Pièges: accès cellule par cellule (risque quotas), cohérence avec Step8 override insertSale_(), labels config sensibles à la casse.
+ * MAJ: 2025-09-26 – Codex Audit
+ */
+/**
  * Scanners Gmail + upserts dans les feuilles.
  * Labels pris depuis Configuration.
  */

--- a/Gmail_Ingest_Run_Optimized.gs
+++ b/Gmail_Ingest_Run_Optimized.gs
@@ -1,4 +1,13 @@
 /**
+ * Module: Gmail_Ingest_Run_Optimized
+ * Rôle: version optimisée de l'ingestion Gmail (batch, cache, pagination, idempotence avancée).
+ * Entrées publiques: ingestAllLabelsFast() et wrappers internes ingestStockJsonFast_(), ingestSalesFast_(), ingestPurchasesVintedFast_(), ingestFavsOffersFast_().
+ * Dépendances: GmailApp, CacheService/PropertiesService (stateGet_/statePut_), parseurs existants, SpreadsheetApp (Stock/Ventes/Achats).
+ * Effets de bord: met à jour labels, remplit les feuilles, persiste des curseurs/procIds dans l'état utilisateur.
+ * Pièges: veillez à purger les caches via step10ClearCaches(), quotas Gmail/UrlFetch selon volume, complexité accrue de pagination.
+ * MAJ: 2025-09-26 – Codex Audit
+ */
+/**
  * Étape 10 — Ingestion optimisée (batch + cache + idempotence rapide)
  * - Ne touche pas à tes anciens parseurs: on réutilise parseStockJsonMessage_, parseSaleMessage_, etc.
  * - Idempotence: on garde un set d'IDs déjà traités dans UserProperties (PROC_IDS) + Logs (fallback).

--- a/Index.html
+++ b/Index.html
@@ -1,3 +1,12 @@
+<!--
+  Module: Index.html
+  Rôle: shell SPA léger utilisant un bootstrap JSON préchargé.
+  Entrées publiques: boutons UI (btnRefreshAll, btnRebuildDash, btnStep3Refs, btnRecalcMargins, btnIngestFast, btnSaveCfg) relayés par Ui App.js.
+  Dépendances: BOOTSTRAP_JSON injecté, inclusion dynamique de 'Ui App.js', google.script.run.* exposés côté client.
+  Effets de bord: prépare la structure DOM et insère dynamiquement le script principal, remplace typographie unicode.
+  Pièges: injection directe de JSON non échappé (surveiller XSS), nécessite ALLOWALL sur HtmlService, large payload bootstrap possible.
+  MAJ: 2025-09-26 – Codex Audit
+-->
 <!DOCTYPE html>
 <html>
   <head>

--- a/Perf_Optim.gs
+++ b/Perf_Optim.gs
@@ -1,4 +1,13 @@
 /**
+ * Module: Perf_Optim
+ * Rôle: journalisation centralisée et maintenance (triggers, purge de caches).
+ * Entrées publiques: logE_(), step10InstallHourlyTrigger(), step10RemoveTriggers(), step10ClearCaches().
+ * Dépendances: SpreadsheetApp (Logs), ScriptApp (triggers), CacheService/PropertiesService (PROC_IDS, THREAD_CURSOR).
+ * Effets de bord: écrit dans Logs, crée/supprime des triggers, vide caches et globals.
+ * Pièges: suppression agressive des caches partagés, attention aux triggers multiples si l'ancien n'est pas retiré.
+ * MAJ: 2025-09-26 – Codex Audit
+ */
+/**
  * Perf_Optim.gs — Logs, triggers et maintenance
  */
 

--- a/PerfendPoints.gs
+++ b/PerfendPoints.gs
@@ -1,3 +1,12 @@
+/**
+ * Module: PerfendPoints
+ * Rôle: version performante des endpoints UI (bootstrap JSON, caches multi-niveaux, diagnostics).
+ * Entrées publiques: openCRM(), ui_getDashboard(), ui_getStockAll(), ui_getVentesAll(), ui_getConfig(), ui_getLogsTail(), ui_step3RefreshRefs(), ui_step8RecalcAll(), ui_saveConfig(), ui_ingestFast(), purge*(), cronRecomputeBootstrap(), setupTriggers().
+ * Dépendances: CacheService (script/document), PropertiesService, SpreadsheetApp (feuilles), HtmlService (Index), Step3/Step8/Ui_Config helpers, timed().
+ * Effets de bord: remplit caches chauds, écrit dans Properties, ouvre modales, peut modifier caches en enveloppant les fonctions existantes.
+ * Pièges: duplication d'endpoints avec Ui_Server (risque conflits), invalidation manuelle nécessaire après modifications, attention aux quotas lors du bootstrap complet.
+ * MAJ: 2025-09-26 – Codex Audit
+ */
 // ===== PerfEndpoints.gs — Full preload + multi-cache + diag =====
 
 // --- Clés de cache

--- a/REPORT.md
+++ b/REPORT.md
@@ -1,0 +1,98 @@
+# Audit technique – CRM Apps Script
+
+## Résumé exécutif
+- **P1 – Corrections bloquantes**
+  - `Ui_Config.gs` contient des doublons de fonctions (`openConfigUI`, `getKnownConfig`, `saveConfigValues`) et se termine par une accolade orpheline (ligne 141) qui produit une erreur de syntaxe lors du chargement du projet. Les handlers de configuration ne peuvent donc pas s’exécuter tant que la fermeture superflue n’est pas supprimée et que les doublons ne sont pas nettoyés.【F:Ui_Config.gs†L14-L141】
+  - `Ui_Server.gs` référence des helpers inexistants (`getDashboardCached_`, `getStockAllRows_`, `getVentesAllRows_`, `softExpireDashboard_`, `purgeStockCache_`, `purgeVentesCache_`) : chaque appel UI (`ui_getDashboard`, `ui_getStockPage`, etc.) déclenche actuellement un `ReferenceError`. Il faut soit réimplémenter ces helpers, soit pointer vers les fonctions disponibles dans `PerfendPoints.gs`/`CRM_DataService.gs`.【F:Ui_Server.gs†L16-L64】
+- **P2 – Risques modérés / performances**
+  - L’ingestion Gmail (`Gmail_Ingest_Run.gs`) écrit cellule par cellule via `getRange().setValue`, ce qui ralentit fortement le traitement quand les boîtes contiennent beaucoup de messages. Un batching (`setValues`) par colonne réduirait le temps d’exécution et la pression sur les quotas.【F:Gmail_Ingest_Run.gs†L65-L128】
+  - Multiples variantes concurrentes des endpoints (`Ui_Server.gs`, `PerfendPoints.gs`, `Ui Server.html`) complexifient le routage et augmentent le risque de divergence ou de cache non invalidé. Centraliser la version performante et désactiver les doublons réduira la maintenance.【F:PerfendPoints.gs†L56-L159】【F:Ui Server.html†L7-L33】
+- **P3 – Améliorations opportunes**
+  - Les vues HTML riches (`CRM_Scripts.html`, `CRM_Config.html`) injectent du HTML construit par concaténation sans échappement systématique. Ajouter un utilitaire `escapeHtml` (à l’image de `Ui App.js`) limiterait les risques XSS.【F:CRM_Scripts.html†L19-L72】
+  - `BackupScriptApi.gs` et `Bordereaux_PDF.gs` manquent de backoff/réessais pour les appels réseau/Drive; prévoir une stratégie `withBackoff_()` homogène améliorerait la robustesse.【F:BackupScriptApi.gs†L18-L88】【F:Bordereaux_PDF.gs†L63-L119】
+
+## Cartographie du projet
+
+### Côté serveur (.gs)
+- **Code.gs** – Menu Sheets (`onOpen`) et ouverture des modales (Index.html, CRM_Config).【F:Code.gs†L1-L41】
+- **CRM_DataService.gs** – Création/formatage des feuilles, calculs Dashboard, requêtes Stock/Ventes/Achats.【F:CRM_DataService.gs†L1-L199】
+- **Dashboard.gs** – Recomposition complète de l’onglet Dashboard (KPI + charts).【F:Dashboard.gs†L1-L109】
+- **Gmail_Ingest_* (Run/Optimized/Parsers)** – Pipelines d’ingestion Gmail standard vs optimisée avec caches et idempotence.【F:Gmail_Ingest_Run.gs†L1-L160】【F:Gmail_Ingest_Run_Optimized.gs†L1-L120】【F:Gmail_Ingest_Parsers.gs†L1-L92】
+- **Step1/2/3/8** – Scripts en cascade pour structurer les feuilles, normaliser SKU/titres, lier Achats↔Stock et calculer marges avancées.【F:Step1_Structure.gs†L1-L80】【F:Step2_SkulTitre.gs†L1-L80】【F:Step3_Liaison_Achats_Stock.gs†L1-L80】【F:Step8 Fees Margins.gs†L1-L90】
+- **PerfendPoints.gs / Ui_Server.gs** – Endpoints exposés à l’UI avec caches (PerfendPoints) ou version paginée historique (Ui_Server).【F:PerfendPoints.gs†L1-L160】【F:Ui_Server.gs†L16-L79】
+- **CRM_ConfigService.gs / Ui_Config.gs** – Gestion de la configuration (lecture/écriture, backup) et pop-up dédiée.【F:CRM_ConfigService.gs†L1-L120】【F:Ui_Config.gs†L14-L140】
+- **BackupScriptApi.gs / Bordereaux_PDF.gs / Perf_Optim.gs / ScanUnicode.gs** – Outils annexes (backup API, génération PDF, triggers, audit Unicode).【F:BackupScriptApi.gs†L1-L101】【F:Bordereaux_PDF.gs†L1-L119】【F:Perf_Optim.gs†L1-L45】【F:ScanUnicode.gs†L1-L24】
+
+### Côté client (HTML/JS/CSS)
+- **Index.html + Ui App.js/html/css** – SPA moderne avec bootstrap JSON, badge réseau, onglets dynamiques.【F:Index.html†L1-L72】【F:Ui App.js.html†L1-L160】【F:Ui app.css.html†L1-L40】
+- **CRM_Interface.html + CRM_Scripts/Styles** – Interface riche héritée (navigation, analytics, config étendue).【F:CRM_Interface.html†L1-L60】【F:CRM_Scripts.html†L1-L72】【F:CRM_Styles.html†L1-L40】
+- **CRM_Config.html** – Modale détaillée de configuration (plateformes, notifications).【F:CRM_Config.html†L1-L40】
+- **index.html + app.js/html** – Prototype minimal utilisé lors des premières étapes.【F:index.html†L1-L40】【F:app.js.html†L1-L30】
+
+## Problèmes détectés (classés)
+
+### Correctness
+1. **P1 – Accolade orpheline + doublons dans Ui_Config** : la fermeture ligne 141 n’a pas d’ouverture correspondante et le fichier redéclare les mêmes fonctions deux fois, ce qui casse le parsing et peut masquer des modifications ultérieures.【F:Ui_Config.gs†L14-L141】 Solution : supprimer la seconde copie des fonctions et l’accolade isolée.
+2. **P1 – Endpoints Ui_Server non fonctionnels** : `ui_getDashboard/ui_getStockPage/ui_getVentesPage` appellent des helpers absents (`getDashboardCached_`, `getStockAllRows_`, etc.), entraînant des `ReferenceError` dès la première invocation depuis l’UI historique.【F:Ui_Server.gs†L16-L64】 Solution : réutiliser les implémentations de `PerfendPoints.gs` (ou de `CRM_DataService.gs`) ou supprimer cette façade.
+3. **P2 – Conflit de nommage `openCRM`** : `Code.gs` et `PerfendPoints.gs` déclarent chacun une fonction `openCRM`. L’ordre de chargement déterminera la version active, ce qui complique le débogage et peut provoquer l’ouverture d’une mauvaise vue.【F:Code.gs†L18-L41】【F:PerfendPoints.gs†L40-L62】 Recommandé : renommer l’une des variantes ou déléguer vers une unique implémentation.
+4. **P3 – `CRM_ConfigService.setConfigValue`** : l’appel `JSON.parse` sur la clé `categories` suppose un JSON valide; la moindre faute de frappe lève une exception silencieusement capturée et renvoie la configuration par défaut.【F:CRM_ConfigService.gs†L73-L104】 Ajouter un `try/catch` dédié ou stocker la liste en colonnes séparées.
+
+### Performance
+1. **P2 – Écritures cellule par cellule lors de l’ingestion** : `upsertStock_`, `insertSale_`, `bumpCounter_` et `ingestPurchasesVinted` font plusieurs `setValue` par ligne, multiplicant les allers-retours SpreadsheetApp.【F:Gmail_Ingest_Run.gs†L65-L152】 Préférer un buffer `values` puis un `setValues` unique (batch) pour chaque ligne traitée.
+2. **P2 – Dashboard rebuild destructif** : `buildDashboard()` appelle `sh.clear()` avant de reconstruire, ce qui efface formats personnalisés ajoutés manuellement par les utilisateurs.【F:Dashboard.gs†L5-L47】 Privilégier `clearContents` + `clearFormats` ciblés.
+3. **P3 – Slides/PDF générés un par un** : `labelsGenerateVisible()` crée une présentation par ligne visible sans pooling ni nettoyage différé.【F:Bordereaux_PDF.gs†L34-L118】 Limiter le nombre de présentations en réutilisant un template.
+
+### UI/UX & réseau
+1. **P2 – HTML injecté sans échappement** : `CRM_Scripts.html` concatène des fragments HTML avec des valeurs issues des feuilles (`updateDashboard`, `updateRecentActivity`). Une donnée utilisateur contenant du HTML sera interprétée.【F:CRM_Scripts.html†L25-L64】 Ajouter un `escapeHtml` uniforme.
+2. **P3 – Multiples SPA concurrentes** : `Index.html` (bootstrap JSON), `Ui App.html` (SPA sombre) et `CRM_Interface.html` coexistent. Sans gouvernance, l’utilisateur peut ouvrir une version obsolète via le menu Sheets (selon la fonction `openCRM` active). Documenter la version supportée et désactiver les autres.
+
+### Stabilité / quotas Apps Script
+1. **P2 – Absence de backoff** : `BackupScriptApi.fetchProjectContent_`/`fetchProjectManifest_` et `Gmail_Ingest_Run` n’intègrent pas de `withBackoff_` alors qu’ils manipulent des APIs sensibles aux limites.【F:BackupScriptApi.gs†L52-L88】【F:Gmail_Ingest_Run_Optimized.gs†L34-L78】 Mutualiser une fonction de retry exponentiel.
+2. **P3 – Caches non purgés** : `PerfendPoints` met en cache le bootstrap/kpi/stock/ventes mais ne purge pas automatiquement lors des écritures directes dans les feuilles (en dehors des fonctions prévues).【F:PerfendPoints.gs†L96-L165】 Prévoir un hook `onEdit` ou rappeler `purge*()` après les scripts d’ingestion.
+
+### Sécurité
+1. **P3 – Scope Script API** : `BackupScriptApi` nécessite `https://www.googleapis.com/auth/script.projects` – scope large pour un CRM. Documenter l’usage et restreindre l’activation à la création d’un backup ponctuel.【F:BackupScriptApi.gs†L9-L16】
+2. **P3 – Absence de validation côté serveur** : `saveConfiguration` écrit directement dans la feuille sans vérifier les types ni les limites (commission >100 %, etc.).【F:CRM_ConfigService.gs†L37-L69】 Ajouter des gardes.
+
+### i18n / encodage
+- Aucun caractère problématique détecté dans le code audité, mais `ScanUnicode.gs` est présent pour le monitoring. Les UI utilisent déjà `...` ASCII via sanitisation dans `Index.html`/`Ui App.js`.【F:Index.html†L49-L63】
+
+### Qualité code
+1. **P2 – Duplication `Ui_Config.gs`** : deux blocs quasi identiques rendent la maintenance pénible et favorisent les divergences.【F:Ui_Config.gs†L14-L137】 Fusionner en une implémentation unique.
+2. **P3 – Mélange de conventions** : coexistence de `const/let/var`, multiples versions d’UI, commentaires en double. Établir des conventions (ES2015+ côté serveur, modules UI rationalisés).
+
+## Recommandations concrètes
+- **Correctifs minimaux (PR séparée)**
+  1. Supprimer la seconde série de fonctions dans `Ui_Config.gs` et l’accolade orpheline; ajouter un test unitaire Apps Script minimal (`getKnownConfig` doit retourner les clés attendues).
+  2. Remplacer les appels à helpers inexistants dans `Ui_Server.gs` par ceux de `PerfendPoints` (ou supprimer la façade pour éviter les collisions) et aligner `openCRM` sur une seule implémentation.
+  3. Introduire des opérations batch (`setValues`) dans les fonctions d’ingestion critiques (Stock/Ventes/Achats) et mutualiser un helper `updateRow_`.
+
+- **Patterns recommandés**
+  - Mettre en place un utilitaire `withBackoff_` commun (déjà présent dans `Gmail_Ingest_Run_Optimized.gs`) pour `UrlFetchApp` et `GmailApp`.
+  - Centraliser les endpoints dans `PerfendPoints` et convertir les autres fichiers (`Ui_Server.gs`, `Ui Server.html`) en wrappers de rétrocompatibilité.
+  - Ajouter un `escapeHtml` partagé dans les vues `CRM_Scripts.html` et `CRM_Config.html` pour toute insertion dynamique.
+  - Documenter l’usage des caches (`purgeDashboardCache`, etc.) et exposer des boutons UI correspondants.
+
+- **Durcissement**
+  - Ajouter des `try/catch` avec `logE_` autour des opérations Drive/Slides (Bordereaux) et Gmail.
+  - Utiliser `console.time` / `logE_` pour mesurer les temps d’ingestion (déjà amorcé dans `Ui App.js` via `console.time('bootstrap')`).
+  - Vérifier les scopes `appsscript.json` et retirer les autorisations inutiles (ex. Script API activé uniquement si backup nécessaire).
+
+## Annexes
+
+### Table des endpoints exposés
+
+| Endpoint serveur | Provenance | Consommateurs UI |
+| --- | --- | --- |
+| `openCRM` | `Code.gs` / `PerfendPoints.gs` | Menu Sheets (modal principale) |
+| `ui_getDashboard` | `PerfendPoints.gs`, `Ui_Server.gs` (défectueux) | `Ui App.js`, `CRM_Scripts.html` |
+| `ui_getStockAll` / `ui_getStockPage` | `PerfendPoints.gs` / `Ui_Server.gs` | `Ui App.js`, `CRM_Scripts.html` |
+| `ui_getVentesAll` / `ui_getVentesPage` | `PerfendPoints.gs` / `Ui_Server.gs` | `Ui App.js`, `CRM_Scripts.html` |
+| `ui_getConfig` / `ui_saveConfig` | `PerfendPoints.gs`, `Ui_Config.gs`, `CRM_ConfigService.gs` | `Ui App.js`, `CRM_Config.html`, `ui_config.html` |
+| `ui_step3RefreshRefs` | `PerfendPoints.gs`, `Ui_Server.gs` | Boutons Step3 (Ui App / Index) |
+| `ui_step8RecalcAll` | `PerfendPoints.gs`, `Ui_Server.gs` | Boutons recalcul marges |
+| `ui_ingestFast` | `PerfendPoints.gs`, `Ui_Server.gs` | Bouton ingestion rapide |
+| `cronRecomputeBootstrap` / `setupTriggers` | `PerfendPoints.gs` | Maintenance (triggers) |
+
+### Latence / mesures
+- Pas de bench chiffré exécuté (environnement offline). Prévoir instrumentation via `console.time` côté serveur lors du prochain sprint.

--- a/ScanUnicode.gs
+++ b/ScanUnicode.gs
@@ -1,3 +1,12 @@
+/**
+ * Module: ScanUnicode
+ * Rôle: audit des caractères unicode problématiques dans le projet Apps Script.
+ * Entrées publiques: scanProjectForUnicode().
+ * Dépendances: ScriptApp (ID), service avancé Script (Script.Projects).
+ * Effets de bord: journalise les lignes suspectes via Logger (pas de modifications).
+ * Pièges: nécessite activer l'API Apps Script, quotas de Script API, regex limitée aux caractères courants.
+ * MAJ: 2025-09-26 – Codex Audit
+ */
 // ===== ScanUnicode.gs — détecte … ’ ‘ “ ” dans tous les fichiers du projet =====
 // Requiert d'activer le service avancé "Apps Script API" (Script)
 

--- a/Step1_Structure.gs
+++ b/Step1_Structure.gs
@@ -1,3 +1,12 @@
+/**
+ * Module: Step1_Structure
+ * Rôle: créer/ordonner les onglets du CRM et appliquer formats, filtres et exemples.
+ * Entrées publiques: runStep1().
+ * Dépendances: SpreadsheetApp (multiples feuilles), log_() (non défini ici), Step3/Step8 hooks via variables globales.
+ * Effets de bord: efface et recrée les feuilles listées, applique formats et protections, insère données de démonstration.
+ * Pièges: destructif (clear contents), attention aux locales (formulaSep_), appels getRange multiples.
+ * MAJ: 2025-09-26 – Codex Audit
+ */
 /** Étape 1 : Structure des onglets + formats + validations */
 function formulaSep_() {
   var loc = SpreadsheetApp.getActive().getSpreadsheetLocale() || "";

--- a/Step2_SkulTitre.gs
+++ b/Step2_SkulTitre.gs
@@ -1,3 +1,12 @@
+/**
+ * Module: Step2_SkulTitre
+ * Rôle: maintenir cohérence SKU/Titre et relayer événements Étape 3 via onEdit.
+ * Entrées publiques: onEdit(e), fixOneStockRow_(), fixOneVenteRow_().
+ * Dépendances: SpreadsheetApp (Stock, Ventes, Achats), Step3 (step3PropagateRow_), Step8 (step8InvalidateCostCache_), log_().
+ * Effets de bord: modifie cellules lors d'éditions, force uppercase, ajoute SKU au titre, déclenche propagation prix.
+ * Pièges: onEdit doit rester rapide (<30s), expressions régulières sur SKU, dépendances conditionnelles (fonctions undefined ignorées).
+ * MAJ: 2025-09-26 – Codex Audit
+ */
 // ==============================
 // FICHIER 2 / 3 : Step2_SkuTitre.gs (COMPLET — VERSION ÉTAPE 3)
 // ==============================

--- a/Step3_Liaison_Achats_Stock.gs
+++ b/Step3_Liaison_Achats_Stock.gs
@@ -1,3 +1,12 @@
+/**
+ * Module: Step3_Liaison_Achats_Stock
+ * Rôle: synchroniser Achats ↔ Stock (références automatiques et propagation des prix).
+ * Entrées publiques: step3RefreshRefs(), step3PropagateAll(), step3PropagateCurrent().
+ * Dépendances: SpreadsheetApp (Achats, Stock), CacheService (STEP3::REF_PRICE_MAP), log_(), Step8 invalidate.
+ * Effets de bord: met à jour validations, remplit colonnes Réf Achat / Prix achat, utilise caches en Properties/Cache.
+ * Pièges: invalidation nécessaire avant recalcul, attention aux appels en masse (getRange volumineux), dépend des entêtes existants.
+ * MAJ: 2025-09-26 – Codex Audit
+ */
 // ==============================
 // FICHIER 3 / 3 : Step3_Liaison_Achats_Stock.gs (COMPLET)
 // ==============================

--- a/Step8 Fees Margins.gs
+++ b/Step8 Fees Margins.gs
@@ -1,4 +1,13 @@
 /**
+ * Module: Step8_Fees_Margins
+ * Rôle: calculer commissions/marges avancées et surcharger insertSale_ pendant l'ingestion.
+ * Entrées publiques: step8RecalcAll(), step8RecalcCurrent(), insertSale_() override, step8CommissionFor_(), step8LookupCostBySku_().
+ * Dépendances: SpreadsheetApp (Ventes, Stock), Config Advanced (getPlatformFees_, getGlobalFlags_), Step3 caches, log_().
+ * Effets de bord: écrit frais/marges dans Ventes, lit coûts dans Stock, met à jour caches STEP8::COST_MAP.
+ * Pièges: override de insertSale_ doit rester compatible avec Gmail_Ingest_Run, conversions num/locale, invalidation caches.
+ * MAJ: 2025-09-26 – Codex Audit
+ */
+/**
  * Étape 8 — Calculs commissions & marges avancés
  * - Calcule la commission par plateforme: max(min, pct*prix + flat)
  * - Marge brute = PV − Prix achat − Commission − Frais port

--- a/Ui App.html
+++ b/Ui App.html
@@ -1,3 +1,12 @@
+<!--
+  Module: Ui App.html
+  Rôle: interface sombre (SPA) embarquée dans HtmlService avec onglets Dashboard/Ventes/Stock/Emails/Config.
+  Entrées publiques: boutons id="btnRebuildDash", "btnRecalcMargins", "btnStep3Refs", "btnIngestFast", navigation data-tab utilisés par Ui App.js.
+  Dépendances: Ui App.js (logiciel client), google.script.run endpoints définis côté serveur.
+  Effets de bord: structure le DOM, affiche placeholders et pager pour tableaux, boutons déclenchent scripts client.
+  Pièges: nécessite injection CSS correspondante, attention aux IDs cohérents avec le JS.
+  MAJ: 2025-09-26 – Codex Audit
+-->
 <!DOCTYPE html>
 <html>
 <head>

--- a/Ui App.js.html
+++ b/Ui App.js.html
@@ -1,3 +1,12 @@
+/**
+ * Module: Ui App.js
+ * Rôle: logique client moderne (promise + badge réseau) pour la SPA principale.
+ * Entrées publiques: boot(), setTab(), run(), handlers sur btnRefreshAll, btnRebuildDash, btnStep3Refs, btnRecalcMargins, btnIngestFast, btnSaveCfg.
+ * Dépendances: google.script.run (ui_getDashboard, ui_getStockAll, ui_getVentesAll, ui_getConfig, ui_getLogsTail, ui_step3RefreshRefs, ui_step8RecalcAll, ui_ingestFast, ui_saveConfig, cron*), payload __BOOTSTRAP__.
+ * Effets de bord: met à jour le DOM, gère état global en mémoire, affiche badge réseau, manipule innerHTML (avec escapeHtml).
+ * Pièges: payload JSON volumineux, éviter multiples appels simultanés (locks), pas de sanitization automatique pour valeurs renvoyées.
+ * MAJ: 2025-09-26 – Codex Audit
+ */
 (function(){
   'use strict';
   console.time('bootstrap');

--- a/Ui Server.html
+++ b/Ui Server.html
@@ -1,3 +1,12 @@
+<!--
+  Module: Ui Server (legacy stub)
+  Rôle: version alternative des endpoints serveur exposés à l'UI HtmlService.
+  Entrées publiques: ui_getDashboard(), ui_getStockPage(), ui_getVentesPage(), ui_getLogsTail(), ui_step3RefreshRefs(), ui_step8RecalcAll(), ui_ingestFast(), ui_getConfig(), ui_saveConfig().
+  Dépendances: SpreadsheetApp (Stock, Ventes, Logs), Step3/Step8, Ui_Config (saveConfigValues), Perf helpers éventuels.
+  Effets de bord: lit les feuilles, déclenche recalculs, purge caches, renvoie tableaux paginés.
+  Pièges: duplication avec Ui_Server.gs/PerfendPoints.gs (risque de divergences), accès cellule par cellule, quotas si pagination élevée.
+  MAJ: 2025-09-26 – Codex Audit
+-->
 /**
  * Ponts serveur pour l'UI (HtmlService SPA)
  * Aucune logique métier nouvelle ici : on appelle les fonctions déjà créées.

--- a/Ui app.css.html
+++ b/Ui app.css.html
@@ -1,3 +1,12 @@
+/*
+ * Module: Ui app.css
+ * Rôle: styles de la SPA sombre (sidebar, tables, formulaires) pour Ui App.html.
+ * Entrées publiques: n/a (injecté via <style><?!= include('Ui app.css.html'); ?></style>).
+ * Dépendances: classes et IDs utilisés par Ui App.html et Ui App.js.
+ * Effets de bord: définit palette sombre, grilles, boutons et pager.
+ * Pièges: éviter conflits avec autres styles HtmlService, pas de @import externe.
+ * MAJ: 2025-09-26 – Codex Audit
+ */
 <style>
   *{box-sizing:border-box}
   body.dark{background:#0f1115;color:#e7e9ee;font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif}

--- a/Ui_Config.gs
+++ b/Ui_Config.gs
@@ -1,3 +1,12 @@
+/**
+ * Module: Ui_Config
+ * Rôle: ouvrir la popup de configuration rapide et exposer les helpers d'upsert des clés.
+ * Entrées publiques: openConfigUI(), getKnownConfig(), saveConfigValues(), include_().
+ * Dépendances: HtmlService (ui_config), SpreadsheetApp (feuille Configuration), Config.gs (getConfig_).
+ * Effets de bord: ouvre un modal Sheets, lit/écrit l'onglet Configuration ligne par ligne.
+ * Pièges: duplications en fin de fichier (fonctions répétées), attention aux locales (trim/uppercase), éviter insertSheet multiple.
+ * MAJ: 2025-09-26 – Codex Audit
+ */
 // ==============================
 // FICHIER 2/4 — Ui_Config.gs (Apps Script, serveur)
 // ==============================

--- a/Ui_Server.gs
+++ b/Ui_Server.gs
@@ -1,4 +1,13 @@
 /**
+ * Module: Ui_Server
+ * Rôle: exposer les endpoints serveur pour l'UI paginée (stock/ventes/dashboard/logs/config).
+ * Entrées publiques: ui_getDashboard(), ui_buildDashboard(), ui_getStockPage(), ui_step3RefreshRefs(), ui_getVentesPage(), ui_step8RecalcAll(), ui_getLogsTail(), ui_ingestFast(), ui_getConfig(), ui_saveConfig().
+ * Dépendances: timed(), getDashboardCached_(), getStockAllRows_(), getVentesAllRows_(), step3RefreshRefs(), step8RecalcAll(), saveConfigValues().
+ * Effets de bord: lit caches internes, invalide caches via purge*, lance recalculs, renvoie tableaux paginés.
+ * Pièges: fonctions dépendantes non définies dans ce fichier (doivent exister ailleurs), duplication avec PerfendPoints/Ui Server.html.
+ * MAJ: 2025-09-26 – Codex Audit
+ */
+/**
  * Ponts serveur pour l'UI popup (HtmlService)
  * — Appelle tes fonctions existantes sans rien réécrire.
  */

--- a/app.css.html
+++ b/app.css.html
@@ -1,3 +1,12 @@
+/*
+ * Module: app.css
+ * Rôle: styles minimalistes pour la maquette index.html (sidebar, vues).
+ * Entrées publiques: n/a (inclusion via include_('app.css.html')).
+ * Dépendances: utilisé par index.html (classes .app, .menu-item, .view).
+ * Effets de bord: définit layout responsive et palette claire.
+ * Pièges: rester compatible HtmlService (pas de @import), attention au chevauchement avec autres CSS.
+ * MAJ: 2025-09-26 – Codex Audit
+ */
 :root {
 --bg: #0b1020;
 --panel: #121a2e;

--- a/app.js.html
+++ b/app.js.html
@@ -1,3 +1,12 @@
+/**
+ * Module: app.js
+ * Rôle: squelette JS minimal (routing, ping serveur) pour index.html.
+ * Entrées publiques: setView(), bind(), handlers sur btnClose et btnPing.
+ * Dépendances: helpers qs/qsa (définis ailleurs), google.script.run.ping? (doit exister côté serveur).
+ * Effets de bord: modifie classes CSS pour afficher les vues, appelle google.script.run et ferme le modal via google.script.host.close().
+ * Pièges: fonctions utilitaires non définies dans ce fichier, ping nécessite endpoint existant, DOM selectors sensibles.
+ * MAJ: 2025-09-26 – Codex Audit
+ */
 /* Utilitaires DOM */
 function qs(sel, root) { return (root || document).querySelector(sel); }
 function qsa(sel, root) { return Array.from((root || document).querySelectorAll(sel)); }

--- a/index.html
+++ b/index.html
@@ -1,3 +1,12 @@
+<!--
+  Module: index.html
+  Rôle: prototype simple d'interface CRM (navigation statique et actions placeholder).
+  Entrées publiques: boutons data-view, btnPing, btnClose utilisés par app.js.
+  Dépendances: include_('app.css.html'), include_('app.js.html'), google.script.run endpoints de test.
+  Effets de bord: structure un layout minimal, fournit zones pour futures données.
+  Pièges: placeholders non reliés aux vraies données, nécessite que les helpers JS soient chargés après DOMContentLoaded.
+  MAJ: 2025-09-26 – Codex Audit
+-->
 <!DOCTYPE html>
 <html lang="fr">
 <head>

--- a/ui_config.html
+++ b/ui_config.html
@@ -1,3 +1,12 @@
+<!--
+  Module: ui_config.html
+  Rôle: formulaire compact de configuration (labels Gmail, commissions, flags).
+  Entrées publiques: formulaire #cfgForm géré par Ui_Config.gs via google.script.run.getKnownConfig/saveConfigValues.
+  Dépendances: Ui_Config.js inclus ailleurs (non présent ici), google.script.run, include('App.css') éventuel.
+  Effets de bord: rendu du formulaire, section actions (btn save via JS).
+  Pièges: champ JSON pour catégories, veillez à synchroniser noms d'inputs avec saveConfigValues().
+  MAJ: 2025-09-26 – Codex Audit
+-->
 <!DOCTYPE html>
 <html>
 <head>


### PR DESCRIPTION
## Summary
- add per-module documentation headers across Apps Script, HTML, JS and CSS assets
- document audit findings and remediation priorities in REPORT.md

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d66d3f4bf483219017878b1a155f95