### PR TITLE
Centralize UI endpoints and harden ingestion/backups

### DIFF
--- a/Bordereaux_PDF.gs
+++ b/Bordereaux_PDF.gs
@@ -6,7 +6,9 @@
  * Effets de bord: met à jour Statut PDF/Lien dans la feuille, crée des fichiers Slides/PDF et les place sur Drive.
  * Pièges: quotas Slides/Drive, nettoyage manuel des présentations, dépendance à la colonne SKU pour retrouver le titre.
  * MAJ: 2025-09-26 – Codex Audit
+ * @change: encapsulation des appels Drive/Slides avec withBackoff_ pour gérer les quotas et échecs transitoires.
  */
+
 /**
  * Étape 6 — Bordereaux (v1 overlay via Google Slides -> PDF)
  * - Lit l’onglet Bordereaux (colonnes: Date, SKU, Titre (avec SKU), N° suivi, Transporteur, Statut PDF, Lien PDF, Notes)
@@ -14,21 +16,21 @@
  * Réf feuille: Bordereaux (Roadmap + entêtes) :contentReference[oaicite:2]{index=2} ; Pipeline attendu: import -> overlay -> export PDF :contentReference[oaicite:3]{index=3}
  */
 
-const SHEET_BORD = "Bordereaux";
-const SHEET_STOCK_LOOKUP = "Stock";
+const SHEET_BORD = 'Bordereaux';
+const SHEET_STOCK_LOOKUP = 'Stock';
 
 // Colonnes Bordereaux (1-based)
 const COL_BORD_DATE = 1;
-const COL_BORD_SKU  = 2;
-const COL_BORD_TIT  = 3;
-const COL_BORD_TRACK= 4;
-const COL_BORD_TRANS= 5;
+const COL_BORD_SKU = 2;
+const COL_BORD_TIT = 3;
+const COL_BORD_TRACK = 4;
+const COL_BORD_TRANS = 5;
 const COL_BORD_STAT = 6;
 const COL_BORD_LINK = 7;
 const COL_BORD_NOTE = 8;
 
 // Page settings
-const LABEL_SIZE = "A6"; // "A6" ou "A4"
+const LABEL_SIZE = 'A6'; // 'A6' ou 'A4'
 const MARGIN_MM = 8;
 
 // --- Entrées menu ---
@@ -43,51 +45,52 @@ function labelsGenerateCurrent() {
 function labelsGenerateVisible() {
   const sh = SpreadsheetApp.getActiveSheet();
   if (!sh || sh.getName() !== SHEET_BORD) return;
-  const rng = sh.getDataRange().offset(1,0, sh.getLastRow()-1); // sans entête
+  const rng = sh.getDataRange().offset(1, 0, sh.getLastRow() - 1); // sans entête
   const values = rng.getValues();
   const display = rng.getDisplayValues(); // pour respecter filtres
-  for (let i=0;i<values.length;i++){
-    // Si ligne masquée par filtre, getDisplayValues renvoie "" pour toutes les cellules visibles du range => heuristique:
-    const rowVisible = display[i].some(v => String(v).length>0);
+  for (let i = 0; i < values.length; i++) {
+    const rowVisible = display[i].some(v => String(v).length > 0);
     if (!rowVisible) continue;
-    generateOneLabelPdf_(sh, i+2);
+    generateOneLabelPdf_(sh, i + 2);
   }
 }
 
 // --- Cœur génération ---
 function generateOneLabelPdf_(sh, row) {
-  const sku = String(sh.getRange(row, COL_BORD_SKU).getValue()||"").trim().toUpperCase();
-  let title = String(sh.getRange(row, COL_BORD_TIT).getValue()||"").trim();
-  const tracking = String(sh.getRange(row, COL_BORD_TRACK).getValue()||"").trim();
-  const trans = String(sh.getRange(row, COL_BORD_TRANS).getValue()||"").trim();
+  const sku = String(sh.getRange(row, COL_BORD_SKU).getValue() || '').trim().toUpperCase();
+  let title = String(sh.getRange(row, COL_BORD_TIT).getValue() || '').trim();
+  const tracking = String(sh.getRange(row, COL_BORD_TRACK).getValue() || '').trim();
+  const trans = String(sh.getRange(row, COL_BORD_TRANS).getValue() || '').trim();
 
-  if (!sku) { sh.getRange(row, COL_BORD_STAT).setValue("KO: SKU manquant"); return; }
+  if (!sku) {
+    sh.getRange(row, COL_BORD_STAT).setValue('KO: SKU manquant');
+    return;
+  }
   if (!title) {
-    // fallback: on va le chercher dans Stock par SKU
-    title = lookupTitleInStock_(sku) || ("Item " + sku);
+    title = lookupTitleInStock_(sku) || ('Item ' + sku);
     sh.getRange(row, COL_BORD_TIT).setValue(title);
   }
 
   try {
     const file = buildLabelPdfFile_(title, sku, tracking, trans);
     sh.getRange(row, COL_BORD_LINK).setValue(file.getUrl());
-    sh.getRange(row, COL_BORD_STAT).setValue("OK");
-  } catch(e) {
-    sh.getRange(row, COL_BORD_STAT).setValue("KO: " + String(e));
+    sh.getRange(row, COL_BORD_STAT).setValue('OK');
+  } catch (e) {
+    sh.getRange(row, COL_BORD_STAT).setValue('KO: ' + String(e));
   }
 }
 
-function lookupTitleInStock_(sku){
+function lookupTitleInStock_(sku) {
   const ss = SpreadsheetApp.getActive();
   const st = ss.getSheetByName(SHEET_STOCK_LOOKUP);
-  if (!st) return "";
+  if (!st) return '';
   const last = st.getLastRow();
-  if (last<2) return "";
-  const rng = st.getRange(2,2,last-1,2).getValues(); // B=SKU,C=Title
-  for (let i=0;i<rng.length;i++){
-    if (String(rng[i][0]).toUpperCase() === sku) return String(rng[i][1]||"");
+  if (last < 2) return '';
+  const rng = st.getRange(2, 2, last - 1, 2).getValues(); // B=SKU,C=Title
+  for (let i = 0; i < rng.length; i++) {
+    if (String(rng[i][0]).toUpperCase() === sku) return String(rng[i][1] || '');
   }
-  return "";
+  return '';
 }
 
 /**
@@ -96,55 +99,49 @@ function lookupTitleInStock_(sku){
  * NB: v1 = overlay propre. (Le “crop auto” d’un PDF existant n’est pas disponible nativement en Apps Script;
  * on pourra plus tard charger une image de fond et ajuster le cadrage.)
  */
-function buildLabelPdfFile_(title, sku, tracking, transporter){
-  // 1) Créer un Slides temporaire
-  const pres = SlidesApp.create("Label " + sku + " " + new Date().toISOString());
+function buildLabelPdfFile_(title, sku, tracking, transporter) {
+  const pres = withBackoff_(() => SlidesApp.create('Label ' + sku + ' ' + new Date().toISOString()));
   const presId = pres.getId();
   const page = pres.getSlides()[0];
 
-  // 2) Dimensions page
-  // A4 = 210x297 mm ; A6 = 105x148 mm — Slides travaille en points (1 pt = 1/72 in)
-  const mmToPoints = mm => (mm/25.4)*72;
-  let pageWmm = 105, pageHmm = 148; // A6 par défaut
-  if (LABEL_SIZE === "A4"){ pageWmm = 210; pageHmm = 297; }
-  const pageW = mmToPoints(pageWmm), pageH = mmToPoints(pageHmm);
+  const mmToPoints = mm => (mm / 25.4) * 72;
+  let pageWmm = 105;
+  let pageHmm = 148;
+  if (LABEL_SIZE === 'A4') {
+    pageWmm = 210;
+    pageHmm = 297;
+  }
+  const pageW = mmToPoints(pageWmm);
+  const pageH = mmToPoints(pageHmm);
   page.getPageElements().forEach(el => el.remove());
-  page.getPageBackground().setSolidFill(255,255,255); // blanc
+  page.getPageBackground().setSolidFill(255, 255, 255);
 
-  // 3) Marges et styles
   const m = mmToPoints(MARGIN_MM);
   const fontBig = 20;
   const fontSmall = 12;
 
-  // 4) Titre principal (wrap)
-  const titleShape = page.insertShape(SlidesApp.ShapeType.TEXT_BOX, m, m, pageW - 2*m, mmToPoints(30));
+  const titleShape = page.insertShape(SlidesApp.ShapeType.TEXT_BOX, m, m, pageW - 2 * m, mmToPoints(30));
   titleShape.getText().setText(title);
   titleShape.getText().getTextStyle().setBold(true).setFontSize(fontBig);
 
-  // 5) SKU en “badge”
   const skuShape = page.insertShape(SlidesApp.ShapeType.ROUNDED_RECTANGLE, pageW - m - mmToPoints(35), m, mmToPoints(35), mmToPoints(16));
-  skuShape.getFill().setSolidFill(0,0,0);
+  skuShape.getFill().setSolidFill(0, 0, 0);
   skuShape.getText().setText(sku);
-  skuShape.getText().getTextStyle().setBold(true).setFontSize(12).setForegroundColor(1,1,1);
+  skuShape.getText().getTextStyle().setBold(true).setFontSize(12).setForegroundColor(1, 1, 1);
   skuShape.getLine().setTransparent();
 
-  // 6) Transporteur + N° suivi
   const infoY = m + mmToPoints(36);
-  const transShape = page.insertShape(SlidesApp.ShapeType.TEXT_BOX, m, infoY, pageW - 2*m, mmToPoints(12));
-  transShape.getText().setText((transporter? transporter + " — " : "") + (tracking? ("Suivi: " + tracking) : ""));
+  const transShape = page.insertShape(SlidesApp.ShapeType.TEXT_BOX, m, infoY, pageW - 2 * m, mmToPoints(12));
+  transShape.getText().setText((transporter ? transporter + ' — ' : '') + (tracking ? ('Suivi: ' + tracking) : ''));
   transShape.getText().getTextStyle().setFontSize(fontSmall);
 
-  // 7) Avertissement bas de page
-  const footer = page.insertShape(SlidesApp.ShapeType.TEXT_BOX, m, pageH - m - mmToPoints(10), pageW - 2*m, mmToPoints(10));
-  footer.getText().setText("Généré par CRM (Étape 6)");
-  footer.getText().getTextStyle().setFontSize(10).setForegroundColor(0.4,0.4,0.4);
+  const footer = page.insertShape(SlidesApp.ShapeType.TEXT_BOX, m, pageH - m - mmToPoints(10), pageW - 2 * m, mmToPoints(10));
+  footer.getText().setText('Généré par CRM (Étape 6)');
+  footer.getText().getTextStyle().setFontSize(10).setForegroundColor(0.4, 0.4, 0.4);
 
-  // 8) Export PDF
-  const blob = DriveApp.getFileById(presId).getAs("application/pdf");
-  const out = DriveApp.createFile(blob).setName("Bordereau_" + sku + ".pdf");
-
-  // 9) Nettoyage (optionnel): supprimer le Slides source
-  DriveApp.getFileById(presId).setTrashed(true);
+  const blob = withBackoff_(() => DriveApp.getFileById(presId).getAs('application/pdf'));
+  const out = withBackoff_(() => DriveApp.createFile(blob).setName('Bordereau_' + sku + '.pdf'));
+  withBackoff_(() => DriveApp.getFileById(presId).setTrashed(true));
 
   return out;
 }

--- a/CRM_Config.html
+++ b/CRM_Config.html
@@ -436,6 +436,15 @@
     // Variables globales
     let configData = {};
 
+    function escapeHtml(value) {
+      return String(value == null ? '' : value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+    }
+
     // Initialisation
     document.addEventListener('DOMContentLoaded', function() {
       loadConfiguration();
@@ -502,7 +511,7 @@
       const container = document.getElementById('categories-list');
       container.innerHTML = categories.map(category => `
         <div class="category-item">
-          <input type="text" class="form-input" value="${category}" readonly>
+          <input type="text" class="form-input" value="${escapeHtml(category)}" readonly>
           <button class="btn btn-outline btn-sm" onclick="removeCategory(this)">🗑️</button>
         </div>
       `).join('');
@@ -520,7 +529,7 @@
       const container = document.getElementById('categories-list');
       const newCategoryHtml = `
         <div class="category-item">
-          <input type="text" class="form-input" value="${categoryName}" readonly>
+          <input type="text" class="form-input" value="${escapeHtml(categoryName)}" readonly>
           <button class="btn btn-outline btn-sm" onclick="removeCategory(this)">🗑️</button>
         </div>
       `;

--- a/CRM_ConfigService.gs
+++ b/CRM_ConfigService.gs
@@ -6,7 +6,9 @@
  * Effets de bord: lit/écrit l'onglet Configuration, crée des classeurs de backup, appelle SpreadsheetApp.create.
  * Pièges: conversions JSON pour listes, risques de quotas Drive lors de backups, cohérence avec structure SHEETS_CONFIG.
  * MAJ: 2025-09-26 – Codex Audit
+ * @change: validation renforcée (pourcentages bornés, JSON sûr) et journalisation claire des entrées invalides.
  */
+
 /**
  * Service de gestion de la configuration CRM
  */
@@ -18,24 +20,23 @@ function getConfiguration() {
   try {
     const ss = SpreadsheetApp.getActiveSpreadsheet();
     const sheet = ss.getSheetByName(SHEETS_CONFIG.CONFIG);
-    
+
     if (!sheet || sheet.getLastRow() <= 1) {
       return getDefaultConfiguration();
     }
-    
+
     const data = sheet.getRange(2, 1, sheet.getLastRow() - 1, 3).getValues();
     const config = getDefaultConfiguration();
-    
-    // Charger les valeurs depuis la feuille
+
     data.forEach(row => {
       const key = row[0];
       const value = row[1];
-      
+
       if (key && value !== '') {
         setConfigValue(config, key, value);
       }
     });
-    
+
     return config;
   } catch (error) {
     console.error('Erreur getConfiguration:', error);
@@ -50,23 +51,23 @@ function saveConfiguration(configData) {
   try {
     const ss = SpreadsheetApp.getActiveSpreadsheet();
     let sheet = ss.getSheetByName(SHEETS_CONFIG.CONFIG);
-    
+
     if (!sheet) {
       sheet = createSheetIfNotExists(ss, SHEETS_CONFIG.CONFIG, ['Clé', 'Valeur', 'Notes']);
     }
-    
-    // Vider la feuille (sauf les en-têtes)
+
+    const sanitized = sanitizeConfigForSave_(configData || {});
+
     if (sheet.getLastRow() > 1) {
       sheet.getRange(2, 1, sheet.getLastRow() - 1, 3).clearContent();
     }
-    
-    // Convertir la configuration en lignes
-    const rows = flattenConfiguration(configData);
-    
+
+    const rows = flattenConfiguration(sanitized);
+
     if (rows.length > 0) {
       sheet.getRange(2, 1, rows.length, 3).setValues(rows);
     }
-    
+
     return { success: true };
   } catch (error) {
     console.error('Erreur saveConfiguration:', error);
@@ -121,23 +122,33 @@ function getDefaultConfiguration() {
 function setConfigValue(config, key, value) {
   const keys = key.split('.');
   let current = config;
-  
+
   for (let i = 0; i < keys.length - 1; i++) {
     if (!current[keys[i]]) {
       current[keys[i]] = {};
     }
     current = current[keys[i]];
   }
-  
+
   const lastKey = keys[keys.length - 1];
-  
-  // Conversion des types
+
   if (value === 'true' || value === 'false') {
     current[lastKey] = value === 'true';
   } else if (!isNaN(value) && value !== '') {
     current[lastKey] = Number(value);
   } else if (key === 'categories') {
-    current[lastKey] = JSON.parse(value);
+    try {
+      const parsed = JSON.parse(value);
+      if (Array.isArray(parsed)) {
+        current[lastKey] = parsed;
+      } else {
+        console.warn('Config categories JSON inattendu, utilisation valeur par défaut []');
+        current[lastKey] = [];
+      }
+    } catch (err) {
+      console.warn('Config categories JSON invalide, utilisation valeur par défaut []', err);
+      current[lastKey] = [];
+    }
   } else {
     current[lastKey] = value;
   }
@@ -148,41 +159,35 @@ function setConfigValue(config, key, value) {
  */
 function flattenConfiguration(config) {
   const rows = [];
-  
+
   function addRow(key, value, notes = '') {
     rows.push([key, value, notes]);
   }
-  
-  // Informations générales
+
   addRow('companyName', config.companyName, 'Nom de l\'entreprise');
   addRow('currency', config.currency, 'Devise utilisée');
-  
-  // Plateformes
+
   Object.keys(config.platforms).forEach(platform => {
     const platformData = config.platforms[platform];
     addRow(`platforms.${platform}.enabled`, platformData.enabled, `${platform} activé`);
     addRow(`platforms.${platform}.commission`, platformData.commission, `Commission ${platform} (%)`);
     addRow(`platforms.${platform}.fees`, platformData.fees, `Frais fixes ${platform} (€)`);
   });
-  
-  // Catégories
+
   addRow('categories', JSON.stringify(config.categories), 'Liste des catégories');
-  
-  // Notifications
+
   Object.keys(config.notifications).forEach(key => {
     addRow(`notifications.${key}`, config.notifications[key], `Notification ${key}`);
   });
-  
-  // Automatisation
+
   Object.keys(config.automation).forEach(key => {
     addRow(`automation.${key}`, config.automation[key], `Automatisation ${key}`);
   });
-  
-  // Sauvegarde
+
   Object.keys(config.backup).forEach(key => {
     addRow(`backup.${key}`, config.backup[key], `Sauvegarde ${key}`);
   });
-  
+
   return rows;
 }
 
@@ -193,24 +198,22 @@ function createBackup() {
   try {
     const sourceSS = SpreadsheetApp.getActiveSpreadsheet();
     const backupSS = SpreadsheetApp.create(`Sauvegarde CRM - ${Utilities.formatDate(new Date(), Session.getScriptTimeZone(), 'dd/MM/yyyy HH:mm')}`);
-    
-    // Copier toutes les feuilles
+
     const sheets = sourceSS.getSheets();
     sheets.forEach(sheet => {
       if (sheet.getName() !== 'Feuille 1') {
         sheet.copyTo(backupSS);
       }
     });
-    
-    // Supprimer la feuille par défaut
+
     const defaultSheet = backupSS.getSheetByName('Feuille 1');
     if (defaultSheet) {
       backupSS.deleteSheet(defaultSheet);
     }
-    
-    return { 
-      success: true, 
-      url: backupSS.getUrl() 
+
+    return {
+      success: true,
+      url: backupSS.getUrl()
     };
   } catch (error) {
     console.error('Erreur createBackup:', error);
@@ -225,10 +228,10 @@ function exportAllData() {
   try {
     const ss = SpreadsheetApp.getActiveSpreadsheet();
     const exportUrl = `https://docs.google.com/spreadsheets/d/${ss.getId()}/export?format=xlsx`;
-    
-    return { 
-      success: true, 
-      url: exportUrl 
+
+    return {
+      success: true,
+      url: exportUrl
     };
   } catch (error) {
     console.error('Erreur exportAllData:', error);
@@ -242,11 +245,11 @@ function exportAllData() {
 function getPlatformCommission(platform) {
   const config = getConfiguration();
   const platformConfig = config.platforms[platform.toLowerCase()];
-  
+
   if (!platformConfig || !platformConfig.enabled) {
     return { commission: 0, fees: 0 };
   }
-  
+
   return {
     commission: platformConfig.commission || 0,
     fees: platformConfig.fees || 0
@@ -258,14 +261,39 @@ function getPlatformCommission(platform) {
  */
 function calculateSaleMargins(platform, price, purchasePrice = 0) {
   const platformCommission = getPlatformCommission(platform);
-  
+
   const fees = (price * platformCommission.commission / 100) + platformCommission.fees;
   const grossMargin = price - purchasePrice - fees;
-  const netMargin = grossMargin; // Peut être étendu avec d'autres coûts
-  
+  const netMargin = grossMargin;
+
   return {
     fees: Math.round(fees * 100) / 100,
     grossMargin: Math.round(grossMargin * 100) / 100,
     netMargin: Math.round(netMargin * 100) / 100
   };
+}
+
+function sanitizeConfigForSave_(configData) {
+  const clone = JSON.parse(JSON.stringify(configData || {}));
+  if (!clone.platforms) {
+    return clone;
+  }
+  Object.keys(clone.platforms).forEach(name => {
+    const platform = clone.platforms[name];
+    if (!platform) return;
+    if ('commission' in platform) {
+      const raw = Number(platform.commission);
+      if (isNaN(raw)) {
+        console.warn(`Commission ${name} invalide (${platform.commission}), valeur réinitialisée à 0`);
+        platform.commission = 0;
+      } else {
+        const clamped = Math.min(100, Math.max(0, raw));
+        if (clamped !== raw) {
+          console.warn(`Commission ${name} hors bornes (${raw}) -> clampée à ${clamped}`);
+        }
+        platform.commission = clamped;
+      }
+    }
+  });
+  return clone;
 }

--- a/CRM_Scripts.html
+++ b/CRM_Scripts.html
@@ -13,6 +13,15 @@ let currentView = 'dashboard';
 let currentData = {};
 let isLoading = false;
 
+function escapeHtml(value) {
+  return String(value == null ? '' : value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 // Initialisation
 document.addEventListener('DOMContentLoaded', function() {
   initializeApp();
@@ -130,10 +139,10 @@ function updateRecentActivity(activities) {
   
   const html = activities.map(activity => `
     <div class="activity-item">
-      <div class="activity-icon">${getActivityIcon(activity.type)}</div>
+      <div class="activity-icon">${escapeHtml(getActivityIcon(activity.type))}</div>
       <div class="activity-content">
-        <div class="activity-title">${activity.title}</div>
-        <div class="activity-time">${formatDate(activity.date)}</div>
+        <div class="activity-title">${escapeHtml(activity.title)}</div>
+        <div class="activity-time">${escapeHtml(formatDate(activity.date))}</div>
       </div>
     </div>
   `).join('');
@@ -168,16 +177,16 @@ function updateStockTable(data) {
   
   const html = data.items.map(item => `
     <tr>
-      <td><strong>${item.sku}</strong></td>
-      <td>${item.title}</td>
-      <td>${item.category}</td>
-      <td>${formatCurrency(item.purchasePrice)}</td>
-      <td>${formatCurrency(item.targetPrice)}</td>
-      <td><span class="status-badge status-${item.status}">${item.status}</span></td>
+      <td><strong>${escapeHtml(item.sku)}</strong></td>
+      <td>${escapeHtml(item.title)}</td>
+      <td>${escapeHtml(item.category)}</td>
+      <td>${escapeHtml(formatCurrency(item.purchasePrice))}</td>
+      <td>${escapeHtml(formatCurrency(item.targetPrice))}</td>
+      <td><span class="status-badge status-${escapeHtml(item.status)}">${escapeHtml(item.status)}</span></td>
       <td>
         <div class="action-buttons">
-          <button class="action-btn action-btn-edit" onclick="editStock('${item.id}')">✏️</button>
-          <button class="action-btn action-btn-delete" onclick="deleteStock('${item.id}')">🗑️</button>
+          <button class="action-btn action-btn-edit" onclick="editStock('${escapeHtml(item.id)}')">✏️</button>
+          <button class="action-btn action-btn-delete" onclick="deleteStock('${escapeHtml(item.id)}')">🗑️</button>
         </div>
       </td>
     </tr>
@@ -193,7 +202,7 @@ function updateStockFilters(data) {
   const categories = [...new Set(data.items.map(item => item.category).filter(Boolean))];
   
   categorySelect.innerHTML = '<option value="">Toutes les catégories</option>' +
-    categories.map(cat => `<option value="${cat}">${cat}</option>`).join('');
+    categories.map(cat => `<option value="${escapeHtml(cat)}">${escapeHtml(cat)}</option>`).join('');
 }
 
 // Ventes
@@ -223,16 +232,16 @@ function updateSalesTable(data) {
   
   const html = data.sales.map(sale => `
     <tr>
-      <td>${formatDate(sale.date)}</td>
-      <td>${sale.platform}</td>
-      <td>${sale.title}</td>
-      <td>${formatCurrency(sale.price)}</td>
-      <td>${formatCurrency(sale.fees)}</td>
-      <td class="${sale.margin >= 0 ? 'text-success' : 'text-danger'}">${formatCurrency(sale.margin)}</td>
+      <td>${escapeHtml(formatDate(sale.date))}</td>
+      <td>${escapeHtml(sale.platform)}</td>
+      <td>${escapeHtml(sale.title)}</td>
+      <td>${escapeHtml(formatCurrency(sale.price))}</td>
+      <td>${escapeHtml(formatCurrency(sale.fees))}</td>
+      <td class="${escapeHtml(sale.margin >= 0 ? 'text-success' : 'text-danger')}">${escapeHtml(formatCurrency(sale.margin))}</td>
       <td>
         <div class="action-buttons">
-          <button class="action-btn action-btn-edit" onclick="editSale('${sale.id}')">✏️</button>
-          <button class="action-btn action-btn-delete" onclick="deleteSale('${sale.id}')">🗑️</button>
+          <button class="action-btn action-btn-edit" onclick="editSale('${escapeHtml(sale.id)}')">✏️</button>
+          <button class="action-btn action-btn-delete" onclick="deleteSale('${escapeHtml(sale.id)}')">🗑️</button>
         </div>
       </td>
     </tr>
@@ -248,7 +257,7 @@ function updateSalesFilters(data) {
   const platforms = [...new Set(data.sales.map(sale => sale.platform).filter(Boolean))];
   
   platformSelect.innerHTML = '<option value="">Toutes les plateformes</option>' +
-    platforms.map(platform => `<option value="${platform}">${platform}</option>`).join('');
+    platforms.map(platform => `<option value="${escapeHtml(platform)}">${escapeHtml(platform)}</option>`).join('');
 }
 
 // Achats
@@ -278,16 +287,16 @@ function updatePurchasesTable(data) {
   
   const html = data.purchases.map(purchase => `
     <tr>
-      <td>${formatDate(purchase.date)}</td>
-      <td>${purchase.supplier}</td>
-      <td>${purchase.description}</td>
-      <td>${formatCurrency(purchase.price)}</td>
-      <td>${purchase.category}</td>
-      <td><span class="status-badge status-${purchase.status}">${purchase.status}</span></td>
+      <td>${escapeHtml(formatDate(purchase.date))}</td>
+      <td>${escapeHtml(purchase.supplier)}</td>
+      <td>${escapeHtml(purchase.description)}</td>
+      <td>${escapeHtml(formatCurrency(purchase.price))}</td>
+      <td>${escapeHtml(purchase.category)}</td>
+      <td><span class="status-badge status-${escapeHtml(purchase.status)}">${escapeHtml(purchase.status)}</span></td>
       <td>
         <div class="action-buttons">
-          <button class="action-btn action-btn-edit" onclick="editPurchase('${purchase.id}')">✏️</button>
-          <button class="action-btn action-btn-delete" onclick="deletePurchase('${purchase.id}')">🗑️</button>
+          <button class="action-btn action-btn-edit" onclick="editPurchase('${escapeHtml(purchase.id)}')">✏️</button>
+          <button class="action-btn action-btn-delete" onclick="deletePurchase('${escapeHtml(purchase.id)}')">🗑️</button>
         </div>
       </td>
     </tr>
@@ -303,7 +312,7 @@ function updatePurchasesFilters(data) {
   const suppliers = [...new Set(data.purchases.map(purchase => purchase.supplier).filter(Boolean))];
   
   supplierSelect.innerHTML = '<option value="">Tous les fournisseurs</option>' +
-    suppliers.map(supplier => `<option value="${supplier}">${supplier}</option>`).join('');
+    suppliers.map(supplier => `<option value="${escapeHtml(supplier)}">${escapeHtml(supplier)}</option>`).join('');
 }
 
 // Analytics
@@ -339,10 +348,10 @@ function updateTopItems(items) {
   
   const html = items.map((item, index) => `
     <div class="activity-item">
-      <div class="activity-icon">${index + 1}</div>
+      <div class="activity-icon">${escapeHtml(index + 1)}</div>
       <div class="activity-content">
-        <div class="activity-title">${item.title}</div>
-        <div class="activity-time">${formatCurrency(item.revenue)} • ${item.sales} ventes</div>
+        <div class="activity-title">${escapeHtml(item.title)}</div>
+        <div class="activity-time">${escapeHtml(formatCurrency(item.revenue))} • ${escapeHtml(item.sales)} ventes</div>
       </div>
     </div>
   `).join('');
@@ -438,7 +447,7 @@ function getSaleForm() {
     </div>
     <div class="form-group">
       <label class="form-label">Date de vente</label>
-      <input type="date" id="sale-date" class="form-input" value="${new Date().toISOString().split('T')[0]}">
+      <input type="date" id="sale-date" class="form-input" value="${escapeHtml(new Date().toISOString().split('T')[0])}">
     </div>
   `;
 }
@@ -469,7 +478,7 @@ function getPurchaseForm() {
     </div>
     <div class="form-group">
       <label class="form-label">Date d'achat</label>
-      <input type="date" id="purchase-date" class="form-input" value="${new Date().toISOString().split('T')[0]}">
+      <input type="date" id="purchase-date" class="form-input" value="${escapeHtml(new Date().toISOString().split('T')[0])}">
     </div>
     <div class="form-group">
       <label class="form-label">Notes</label>
@@ -600,7 +609,7 @@ function showModal(title, body, buttons) {
   
   const footer = document.getElementById('modal-footer');
   footer.innerHTML = buttons.map(btn => 
-    `<button class="btn ${btn.class}" onclick="${btn.action}">${btn.text}</button>`
+    `<button class="btn ${escapeHtml(btn.class)}" onclick="${escapeHtml(btn.action)}">${escapeHtml(btn.text)}</button>`
   ).join('');
   
   document.getElementById('modal-overlay').classList.remove('hidden');

--- a/Dashboard.gs
+++ b/Dashboard.gs
@@ -6,177 +6,166 @@
  * Effets de bord: efface et réécrit l'onglet Dashboard, crée des charts, lit massivement les données.
  * Pièges: appels coûteux si feuilles volumineuses (préférer caches), conversions Date/Number, veiller à ne pas supprimer filtres personnalisés.
  * MAJ: 2025-09-26 – Codex Audit
+ * @change: nettoyage ciblé et charts conservés quand possible (plus de sheet.clear destructif).
  */
+
 /** Étape 9 — Dashboard : KPI + Graphiques (idempotent) */
 
 function buildDashboard() {
   const ss = SpreadsheetApp.getActive();
-  const sh = ss.getSheetByName("Dashboard") || ss.insertSheet("Dashboard");
-  sh.clear(); // on repart propre
+  const sh = ss.getSheetByName('Dashboard') || ss.insertSheet('Dashboard');
+  if (sh.getFrozenRows() < 1) {
+    sh.setFrozenRows(1);
+  }
 
-  // --- Récup données ---
-  const ventes = ss.getSheetByName("Ventes");
-  const stock  = ss.getSheetByName("Stock");
-  const boosts = ss.getSheetByName("Boosts");
-  const costs  = ss.getSheetByName("Coûts fonctionnement");
+  const ventes = ss.getSheetByName('Ventes');
+  const stock = ss.getSheetByName('Stock');
+  const boosts = ss.getSheetByName('Boosts');
+  const costs = ss.getSheetByName('Coûts fonctionnement');
 
-  // Ventes
   let rowsV = [];
   if (ventes && ventes.getLastRow() >= 2) {
-    rowsV = ventes.getRange(2,1, ventes.getLastRow()-1, Math.max(10, ventes.getLastColumn())).getValues();
+    rowsV = ventes.getRange(2, 1, ventes.getLastRow() - 1, Math.max(10, ventes.getLastColumn())).getValues();
   }
-  // Stock
   let rowsS = [];
   if (stock && stock.getLastRow() >= 2) {
-    rowsS = stock.getRange(2,1, stock.getLastRow()-1, Math.max(15, stock.getLastColumn())).getValues();
+    rowsS = stock.getRange(2, 1, stock.getLastRow() - 1, Math.max(15, stock.getLastColumn())).getValues();
   }
-  // Boosts
   let rowsB = [];
   if (boosts && boosts.getLastRow() >= 2) {
-    rowsB = boosts.getRange(2,1, boosts.getLastRow()-1, Math.max(6, boosts.getLastColumn())).getValues();
+    rowsB = boosts.getRange(2, 1, boosts.getLastRow() - 1, Math.max(6, boosts.getLastColumn())).getValues();
   }
-  // Coûts fixes
   let rowsC = [];
   if (costs && costs.getLastRow() >= 2) {
-    rowsC = costs.getRange(2,1, costs.getLastRow()-1, Math.max(5, costs.getLastColumn())).getValues();
+    rowsC = costs.getRange(2, 1, costs.getLastRow() - 1, Math.max(5, costs.getLastColumn())).getValues();
   }
 
-  // --- KPI principaux ---
   const kpi = computeKPIs_(rowsV, rowsS, rowsB, rowsC);
 
-  // --- Pose tableau KPI ---
-  const headers = ["KPI","Valeur"];
+  const headers = ['KPI', 'Valeur'];
   const kv = [
-    ["CA total", kpi.revenue],
-    ["Marge brute", kpi.gross],
-    ["Marge nette", kpi.net],
-    ["Nb ventes", kpi.countSales],
-    ["AOV (panier moyen)", kpi.aov],
-    ["Repeat rate acheteurs", kpi.repeatRateStr],
-    ["Valeur stock (prix cible)", kpi.stockValue],
-    ["Coûts fixes cumulés", kpi.costsTotal],
-    ["Coût Boosts", kpi.boostsTotal],
-    ["ROI Boosts", kpi.roiBoostsStr],
-    ["Favoris (total)", kpi.favs],
-    ["Offres (total)", kpi.offers],
+    ['CA total', kpi.revenue],
+    ['Marge brute', kpi.gross],
+    ['Marge nette', kpi.net],
+    ['Nb ventes', kpi.countSales],
+    ['AOV (panier moyen)', kpi.aov],
+    ['Repeat rate acheteurs', kpi.repeatRateStr],
+    ['Valeur stock (prix cible)', kpi.stockValue],
+    ['Coûts fixes cumulés', kpi.costsTotal],
+    ['Coût Boosts', kpi.boostsTotal],
+    ['ROI Boosts', kpi.roiBoostsStr],
+    ['Favoris (total)', kpi.favs],
+    ['Offres (total)', kpi.offers]
   ];
-  sh.getRange(1,1,1,2).setValues([headers]).setFontWeight("bold");
-  sh.getRange(2,1,kv.length,2).setValues(kv);
-  sh.setColumnWidths(1,2,200);
-  sh.setFrozenRows(1);
 
-  // --- Données auxiliaires pour graphiques ---
-  const block1 = buildMonthlyRevenue_(rowsV);              // [ [Mois, CA] ]
-  const block2 = buildPlatformSplit_(rowsV);               // [ [Plateforme, CA] ]
-  const block3 = [["Type","Total"],["Favoris",kpi.favs],["Offres",kpi.offers]];
+  const block1 = buildMonthlyRevenue_(rowsV);
+  const block2 = buildPlatformSplit_(rowsV);
+  const block3 = [['Type', 'Total'], ['Favoris', kpi.favs], ['Offres', kpi.offers]];
 
-  // Écrire ces blocs à droite (pour servir de data range aux charts)
+  const block1Width = block1[0]?.length || 0;
+  const block2Width = block2[0]?.length || 0;
+  const block3Width = block3[0]?.length || 0;
+  const requiredRows = Math.max(kv.length + 2, block1.length + 6, block2.length + 6, block3.length + 6, 35);
+  const requiredCols = Math.max(5 + block1Width + 2 + block2Width + 2 + block3Width, 12);
+  ensureCapacity_(sh, requiredRows, requiredCols);
+
+  const rowsToClear = Math.min(requiredRows - 1, Math.max(0, sh.getMaxRows() - 1));
+  const colsToClear = Math.min(Math.max(requiredCols, 10), sh.getMaxColumns());
+  if (rowsToClear > 0 && colsToClear > 0) {
+    clearRange_(sh, 2, 1, rowsToClear, colsToClear);
+  }
+
+  sh.getRange(1, 1, 1, headers.length).setValues([headers]).setFontWeight('bold');
+  if (kv.length) {
+    sh.getRange(2, 1, kv.length, headers.length).setValues(kv);
+  }
+  sh.setColumnWidths(1, 2, 200);
+
   let col = 5;
-  col = putBlock_(sh, 1, col, "CA mensuel", block1);
-  col = putBlock_(sh, 1, col+2, "CA par plateforme", block2);
-  putBlock_(sh, 1, col+2, "Favoris / Offres", block3);
+  col = putBlock_(sh, 1, col, 'CA mensuel', block1);
+  col = putBlock_(sh, 1, col + 2, 'CA par plateforme', block2);
+  putBlock_(sh, 1, col + 2, 'Favoris / Offres', block3);
 
-  // --- Graphiques ---
-  // Nettoie les charts existants
-  sh.getCharts().forEach(c => sh.removeChart(c));
+  const r1 = block1.length > 1 ? sh.getRange(2, 5, block1.length - 1, block1Width) : null;
+  const r2StartCol = 7 + (block1Width ? block1Width - 2 : 0);
+  const r2 = block2.length > 1 ? sh.getRange(2, r2StartCol, block2.length - 1, block2Width) : null;
+  const r3StartCol = 9 + (block1Width ? block1Width - 2 : 0) + (block2Width ? block2Width - 2 : 0) + 2;
+  const r3 = sh.getRange(2, r3StartCol, 2, block3Width);
 
-  // 1) Ligne CA mensuel
-  const r1 = sh.getRange(2,5, Math.max(1, block1.length-1), 2);
-  if (block1.length > 1) {
-    const ch1 = sh.newChart()
-      .asLineChart()
-      .setPosition(1, 9, 0, 0)
-      .addRange(r1)
-      .setOption('title', 'CA par mois')
-      .build();
-    sh.insertChart(ch1);
-  }
+  ensureChart_(sh, 'CA par mois', builder => {
+    builder.asLineChart();
+    if (r1) builder.addRange(r1);
+    builder.setOption('title', 'CA par mois');
+    builder.setPosition(1, 9, 0, 0);
+  }, Boolean(r1));
 
-  // 2) Pie split plateformes
-  const r2 = sh.getRange(2, 7 + (block1[0]?.length? (block1[0].length-2) : 0), Math.max(1, block2.length-1), 2);
-  if (block2.length > 1) {
-    const ch2 = sh.newChart()
-      .asPieChart()
-      .setPosition(16, 9, 0, 0)
-      .addRange(r2)
-      .setOption('title', 'Répartition CA par plateforme')
-      .build();
-    sh.insertChart(ch2);
-  }
+  ensureChart_(sh, 'Répartition CA par plateforme', builder => {
+    builder.asPieChart();
+    if (r2) builder.addRange(r2);
+    builder.setOption('title', 'Répartition CA par plateforme');
+    builder.setPosition(16, 9, 0, 0);
+  }, Boolean(r2));
 
-  // 3) Bar favoris/offres
-  const r3 = sh.getRange(2, 9 + (block1[0]?.length? (block1[0].length-2) : 0) + (block2[0]?.length? (block2[0].length-2) : 0) + 2, 2, 2);
-  const ch3 = sh.newChart()
-    .asColumnChart()
-    .setPosition(31, 9, 0, 0)
-    .addRange(r3)
-    .setOption('title', 'Favoris / Offres')
-    .build();
-  sh.insertChart(ch3);
+  ensureChart_(sh, 'Favoris / Offres', builder => {
+    builder.asColumnChart();
+    builder.addRange(r3);
+    builder.setOption('title', 'Favoris / Offres');
+    builder.setPosition(31, 9, 0, 0);
+  }, true);
 }
 
 // ===== Helpers KPI =====
 function computeKPIs_(rowsV, rowsS, rowsB, rowsC) {
-  // Indices Ventes (1-based dans la feuille) -> 0-based ici
-  const IDX_V_DATE = 0;   // A
-  const IDX_V_PLATFORM = 1;// B
-  const IDX_V_PRICE = 3;  // D
-  const IDX_V_FEES = 4;   // E
-  const IDX_V_SHIP = 5;   // F
-  const IDX_V_BUYER = 6;  // G
-  const IDX_V_SKU = 7;    // H
-  const IDX_V_GROSS = 8;  // I
-  const IDX_V_NET = 9;    // J
+  const IDX_V_DATE = 0;
+  const IDX_V_PLATFORM = 1;
+  const IDX_V_PRICE = 3;
+  const IDX_V_FEES = 4;
+  const IDX_V_SHIP = 5;
+  const IDX_V_BUYER = 6;
+  const IDX_V_SKU = 7;
+  const IDX_V_GROSS = 8;
+  const IDX_V_NET = 9;
 
-  // Stock : prix cible J (col 10), statut K (11), fav L? (14), offers M? (15)
-  const IDX_S_SKU = 1;     // B
-  const IDX_S_TITLE = 2;   // C
-  const IDX_S_COST = 8;    // I (prix achat link)
-  const IDX_S_TARGET = 9;  // J (prix cible)
-  const IDX_S_STATUS = 10; // K
-  const IDX_S_FAV = 13;    // N? -> dans notre structure: Favoris = col 14 => index 13
-  const IDX_S_OFFER = 14;  // Offres = col 15 => index 14
+  const IDX_S_SKU = 1;
+  const IDX_S_TITLE = 2;
+  const IDX_S_COST = 8;
+  const IDX_S_TARGET = 9;
+  const IDX_S_STATUS = 10;
+  const IDX_S_FAV = 13;
+  const IDX_S_OFFER = 14;
 
-  // Boosts : date A(0), platform B(1), type C(2), cible D(3), coût E(4)
   const IDX_B_COST = 4;
-
-  // Costs : date A(0), cat B(1), lib C(2), montant D(3)
   const IDX_C_AMOUNT = 3;
 
-  // Ventes
   const validV = rowsV.filter(r => r[IDX_V_DATE]);
   const revenue = sum_(validV.map(r => num_(r[IDX_V_PRICE])));
-  const gross   = sum_(validV.map(r => num_(r[IDX_V_GROSS])));
-  const net     = sum_(validV.map(r => num_(r[IDX_V_NET])));
+  const gross = sum_(validV.map(r => num_(r[IDX_V_GROSS])));
+  const net = sum_(validV.map(r => num_(r[IDX_V_NET])));
   const countSales = validV.length;
   const aov = countSales ? round2_(revenue / countSales) : 0;
 
-  // Repeat rate acheteurs
-  const buyers = validV.map(r => String(r[IDX_V_BUYER]||"").trim()).filter(Boolean);
+  const buyers = validV.map(r => String(r[IDX_V_BUYER] || '').trim()).filter(Boolean);
   const buyerCount = new Set(buyers).size || 0;
   const repeats = (() => {
     const freq = {};
-    buyers.forEach(b => freq[b] = (freq[b]||0)+1);
-    return Object.values(freq).filter(n => n>1).length;
+    buyers.forEach(b => { freq[b] = (freq[b] || 0) + 1; });
+    return Object.values(freq).filter(n => n > 1).length;
   })();
   const repeatRate = buyerCount ? repeats / buyerCount : 0;
 
-  // Valeur stock (prix cible) sur items non “Vendu” (si statut présent)
   const stockRows = rowsS.filter(r => r[IDX_S_TARGET]);
   const remaining = stockRows.filter(r => {
-    const st = String(r[IDX_S_STATUS]||"").toLowerCase();
-    return !(st === "vendu" || st === "sold");
+    const st = String(r[IDX_S_STATUS] || '').toLowerCase();
+    return !(st === 'vendu' || st === 'sold');
   });
   const stockValue = sum_(remaining.map(r => num_(r[IDX_S_TARGET])));
 
-  // Favoris / Offres totals
   const favs = sum_(rowsS.map(r => num_(r[IDX_S_FAV])));
   const offers = sum_(rowsS.map(r => num_(r[IDX_S_OFFER])));
 
-  // Coûts & Boosts
   const boostsTotal = sum_(rowsB.map(r => num_(r[IDX_B_COST])));
-  const costsTotal  = sum_(rowsC.map(r => num_(r[IDX_C_AMOUNT])));
-  const roiBoosts   = boostsTotal > 0 ? (net - boostsTotal) / boostsTotal : null;
+  const costsTotal = sum_(rowsC.map(r => num_(r[IDX_C_AMOUNT])));
+  const roiBoosts = boostsTotal > 0 ? (net - boostsTotal) / boostsTotal : null;
 
   return {
     revenue: round2_(revenue),
@@ -184,54 +173,104 @@ function computeKPIs_(rowsV, rowsS, rowsB, rowsC) {
     net: round2_(net),
     countSales,
     aov,
-    repeatRateStr: (repeatRate*100).toFixed(1) + " %",
+    repeatRateStr: (repeatRate * 100).toFixed(1) + ' %',
     stockValue: round2_(stockValue),
     costsTotal: round2_(costsTotal),
     boostsTotal: round2_(boostsTotal),
-    roiBoostsStr: roiBoosts==null ? "n/a" : (roiBoosts*100).toFixed(1)+" %",
+    roiBoostsStr: roiBoosts == null ? 'n/a' : (roiBoosts * 100).toFixed(1) + ' %',
     favs: round0_(favs),
     offers: round0_(offers)
   };
 }
 
-function buildMonthlyRevenue_(rowsV){
-  // renvoie [[Mois, CA], ...] avec Mois = 2025-01
-  if (!rowsV.length) return [["Mois","CA"]];
+function buildMonthlyRevenue_(rowsV) {
+  if (!rowsV.length) return [['Mois', 'CA']];
   const IDX_DATE = 0, IDX_PRICE = 3;
   const map = {};
   rowsV.forEach(r => {
     const d = r[IDX_DATE];
     if (!d) return;
-    const y = d.getFullYear ? d.getFullYear() : new Date(d).getFullYear();
-    const m = d.getMonth ? (d.getMonth()+1) : (new Date(d).getMonth()+1);
-    const key = y + "-" + String(m).padStart(2,"0");
-    map[key] = (map[key]||0) + num_(r[IDX_PRICE]);
+    const baseDate = d instanceof Date ? d : new Date(d);
+    const key = baseDate.getFullYear() + '-' + String(baseDate.getMonth() + 1).padStart(2, '0');
+    map[key] = (map[key] || 0) + num_(r[IDX_PRICE]);
   });
   const keys = Object.keys(map).sort();
-  return [["Mois","CA"]].concat(keys.map(k => [k, round2_(map[k])]));
+  return [['Mois', 'CA']].concat(keys.map(k => [k, round2_(map[k])]));
 }
 
-function buildPlatformSplit_(rowsV){
-  // renvoie [[Plateforme, CA]]
-  if (!rowsV.length) return [["Plateforme","CA"]];
+function buildPlatformSplit_(rowsV) {
+  if (!rowsV.length) return [['Plateforme', 'CA']];
   const IDX_PLATFORM = 1, IDX_PRICE = 3;
   const map = {};
   rowsV.forEach(r => {
-    const p = String(r[IDX_PLATFORM]||"").trim() || "Autre";
-    map[p] = (map[p]||0) + num_(r[IDX_PRICE]);
+    const p = String(r[IDX_PLATFORM] || '').trim() || 'Autre';
+    map[p] = (map[p] || 0) + num_(r[IDX_PRICE]);
   });
   const keys = Object.keys(map).sort();
-  return [["Plateforme","CA"]].concat(keys.map(k => [k, round2_(map[k])]));
+  return [['Plateforme', 'CA']].concat(keys.map(k => [k, round2_(map[k])]));
 }
 
-function putBlock_(sh, row, col, title, block){
-  sh.getRange(row, col, 1, 1).setValue(title).setFontWeight("bold");
-  if (block.length) sh.getRange(row+1, col, block.length, block[0].length).setValues(block);
-  return col + (block[0]?.length || 2);
+function putBlock_(sh, row, col, title, block) {
+  const width = block[0]?.length || 2;
+  const height = block.length;
+  clearRange_(sh, row, col, height + 1, width);
+  sh.getRange(row, col, 1, 1).setValue(title).setFontWeight('bold');
+  if (height) {
+    sh.getRange(row + 1, col, height, width).setValues(block);
+  }
+  return col + width;
+}
+
+function ensureChart_(sheet, title, configureBuilder, hasData) {
+  const chart = findChartByTitle_(sheet, title);
+  if (!hasData) {
+    if (chart) {
+      sheet.removeChart(chart);
+    }
+    return;
+  }
+  if (chart) {
+    const builder = chart.modify();
+    builder.clearRanges();
+    configureBuilder(builder, false);
+    sheet.updateChart(builder.build());
+  } else {
+    const builder = sheet.newChart();
+    configureBuilder(builder, true);
+    sheet.insertChart(builder.build());
+  }
+}
+
+function findChartByTitle_(sheet, title) {
+  const charts = sheet.getCharts();
+  for (let i = 0; i < charts.length; i++) {
+    const c = charts[i];
+    const chartTitle = c.getOptions().title || '';
+    if (chartTitle === title) {
+      return c;
+    }
+  }
+  return null;
+}
+
+function clearRange_(sheet, row, col, numRows, numCols) {
+  if (numRows <= 0 || numCols <= 0) {
+    return;
+  }
+  sheet.getRange(row, col, numRows, numCols).clearContent();
+}
+
+function ensureCapacity_(sheet, minRows, minCols) {
+  if (sheet.getMaxRows() < minRows) {
+    sheet.insertRowsAfter(sheet.getMaxRows(), minRows - sheet.getMaxRows());
+  }
+  if (sheet.getMaxColumns() < minCols) {
+    sheet.insertColumnsAfter(sheet.getMaxColumns(), minCols - sheet.getMaxColumns());
+  }
 }
 
 // small math helpers
-function num_(v){ const n = Number(String(v).replace(',','.')); return isFinite(n)? n : 0; }
-function sum_(arr){ return arr.reduce((a,b)=>a+num_(b),0); }
-function round2_(n){ return Math.round(n*100)/100; }
-function round0_(n){ return Math.round(n||0); }
+function num_(v) { const n = Number(String(v).replace(',', '.')); return isFinite(n) ? n : 0; }
+function sum_(arr) { return arr.reduce((a, b) => a + num_(b), 0); }
+function round2_(n) { return Math.round(n * 100) / 100; }
+function round0_(n) { return Math.round(n || 0); }

--- a/Gmail_Ingest_Run.gs
+++ b/Gmail_Ingest_Run.gs
@@ -6,194 +6,321 @@
  * Effets de bord: marque les threads Traite/Erreur, upsert des lignes dans Stock/Ventes/Achats, incrémente compteurs.
  * Pièges: accès cellule par cellule (risque quotas), cohérence avec Step8 override insertSale_(), labels config sensibles à la casse.
  * MAJ: 2025-09-26 – Codex Audit
- */
-/**
- * Scanners Gmail + upserts dans les feuilles.
- * Labels pris depuis Configuration.
+ * @change: écriture batch setValues, instrumentation console.time et backoff unifié pour Gmail.
  */
 
+const STOCK_SHEET_NAME = 'Stock';
+const SALES_SHEET_NAME = 'Ventes';
+const PURCHASES_SHEET_NAME = 'Achats';
+const DEFAULT_LABEL_DONE = 'Traite';
+const DEFAULT_LABEL_ERROR = 'Erreur';
+
 // ---- Raccourcis labels (avec valeurs par défaut si la Config est vide) ----
-function labels_(){
+function labels_() {
   return {
-    INGEST_STOCK: String(cfg_("GMAIL_LABEL_INGEST_STOCK","Ingestion/Stock")),
-    SALES_VINTED: String(cfg_("GMAIL_LABEL_SALES_VINTED","Sales/Vinted")),
-    SALES_VESTIAIRE: String(cfg_("GMAIL_LABEL_SALES_VESTIAIRE","Sales/Vestiaire")),
-    SALES_EBAY: String(cfg_("GMAIL_LABEL_SALES_EBAY","Sales/eBay")),
-    SALES_LEBONCOIN: String(cfg_("GMAIL_LABEL_SALES_LEBONCOIN","Sales/Leboncoin")),
-    SALES_WHATNOT: String(cfg_("GMAIL_LABEL_SALES_WHATNOT","Sales/Whatnot")),
-    FAV_VINTED: String(cfg_("GMAIL_LABEL_FAVORITES_VINTED","Favorites/Vinted")),
-    OFF_VINTED: String(cfg_("GMAIL_LABEL_OFFERS_VINTED","Offers/Vinted")),
-    PUR_VINTED: String(cfg_("GMAIL_LABEL_PURCHASES_VINTED","Purchases/Vinted")),
+    INGEST_STOCK: String(cfg_('GMAIL_LABEL_INGEST_STOCK', 'Ingestion/Stock')),
+    SALES_VINTED: String(cfg_('GMAIL_LABEL_SALES_VINTED', 'Sales/Vinted')),
+    SALES_VESTIAIRE: String(cfg_('GMAIL_LABEL_SALES_VESTIAIRE', 'Sales/Vestiaire')),
+    SALES_EBAY: String(cfg_('GMAIL_LABEL_SALES_EBAY', 'Sales/eBay')),
+    SALES_LEBONCOIN: String(cfg_('GMAIL_LABEL_SALES_LEBONCOIN', 'Sales/Leboncoin')),
+    SALES_WHATNOT: String(cfg_('GMAIL_LABEL_SALES_WHATNOT', 'Sales/Whatnot')),
+    FAV_VINTED: String(cfg_('GMAIL_LABEL_FAVORITES_VINTED', 'Favorites/Vinted')),
+    OFF_VINTED: String(cfg_('GMAIL_LABEL_OFFERS_VINTED', 'Offers/Vinted')),
+    PUR_VINTED: String(cfg_('GMAIL_LABEL_PURCHASES_VINTED', 'Purchases/Vinted'))
   };
 }
 
+// ---- Helpers backoff ----
+function ensureLabel_(name) {
+  const existing = withBackoff_(() => GmailApp.getUserLabelByName(name));
+  return existing || withBackoff_(() => GmailApp.createLabel(name));
+}
+
+function searchThreads_(query, start, max) {
+  return withBackoff_(() => GmailApp.search(query, start, max));
+}
+
+function threadMessages_(thread) {
+  return withBackoff_(() => thread.getMessages());
+}
+
+function threadAddLabel_(thread, label) {
+  return withBackoff_(() => thread.addLabel(label));
+}
+
 // ---- Orchestrateur ----
-function ingestAllLabels(){
-  ingestStockJson();
-  ingestSales();
-  ingestPurchasesVinted();
-  ingestFavsOffersVinted();
+function ingestAllLabels() {
+  console.time('ingestAllLabels');
+  try {
+    ingestStockJson();
+    ingestSales();
+    ingestPurchasesVinted();
+    ingestFavsOffersVinted();
+  } finally {
+    console.timeEnd('ingestAllLabels');
+  }
 }
 
 // ---- STOCK via JSON ----
-function ingestStockJson(){
-  const l = labels_().INGEST_STOCK; // Ingestion/Stock
-  const threadQuery = 'label:"' + l + '" -label:Traite -label:Erreur';
-  const threads = GmailApp.search(threadQuery, 0, 50);
-  const labelDone = GmailApp.getUserLabelByName("Traite") || GmailApp.createLabel("Traite");
-  const labelErr  = GmailApp.getUserLabelByName("Erreur") || GmailApp.createLabel("Erreur");
-
-  const ss = SpreadsheetApp.getActive();
-  const sh = ss.getSheetByName("Stock");
-  for (let t of threads){
-    const msgs = t.getMessages();
-    for (let m of msgs){
-      const parsed = parseStockJsonMessage_(m);
-      if (!parsed) continue;
-      try {
-        upsertStock_(sh, parsed.data);
-        t.addLabel(labelDone);
-        markProcessed_("INFO","ingestStockJson","OK", "", parsed.id);
-      } catch(e){
-        t.addLabel(labelErr);
-        markProcessed_("ERROR","ingestStockJson","KO", String(e), parsed.id);
-      }
+function ingestStockJson() {
+  console.time('ingestStockJson');
+  try {
+    const l = labels_().INGEST_STOCK;
+    const threadQuery = 'label:"' + l + '" -label:' + DEFAULT_LABEL_DONE + ' -label:' + DEFAULT_LABEL_ERROR;
+    const threads = searchThreads_(threadQuery, 0, 50);
+    if (!threads.length) {
+      return;
     }
+
+    const labelDone = ensureLabel_(DEFAULT_LABEL_DONE);
+    const labelErr = ensureLabel_(DEFAULT_LABEL_ERROR);
+    const ss = SpreadsheetApp.getActive();
+    const sh = ss.getSheetByName(STOCK_SHEET_NAME);
+    if (!sh) {
+      return;
+    }
+
+    threads.forEach(thread => {
+      const msgs = threadMessages_(thread);
+      msgs.forEach(msg => {
+        const parsed = parseStockJsonMessage_(msg);
+        if (!parsed) {
+          return;
+        }
+        try {
+          upsertStock_(sh, parsed.data);
+          threadAddLabel_(thread, labelDone);
+          markProcessed_('INFO', 'ingestStockJson', 'OK', '', parsed.id);
+        } catch (err) {
+          threadAddLabel_(thread, labelErr);
+          markProcessed_('ERROR', 'ingestStockJson', 'KO', String(err), parsed.id);
+        }
+      });
+    });
+  } finally {
+    console.timeEnd('ingestStockJson');
   }
 }
 
-function upsertStock_(sh, obj){
-  const headers = { sku:2, title:3, photos:4, category:5, brand:6, size:7, condition:8, platform:12 };
+function upsertStock_(sh, obj) {
+  const headers = { sku: 2, title: 3, photos: 4, category: 5, brand: 6, size: 7, condition: 8, platform: 12 };
   const last = sh.getLastRow();
   let row = 0;
-  if (last>=2){
-    const rng = sh.getRange(2,2,last-1,1).getValues();
-    for (let i=0;i<rng.length;i++){ if (String(rng[i][0]).toUpperCase() === String(obj.sku).toUpperCase()) { row = i+2; break; } }
+  if (last >= 2) {
+    const rng = sh.getRange(2, headers.sku, last - 1, 1).getValues();
+    for (let i = 0; i < rng.length; i++) {
+      if (String(rng[i][0]).toUpperCase() === String(obj.sku).toUpperCase()) {
+        row = i + 2;
+        break;
+      }
+    }
   }
-  if (!row){ row = Math.max(2, last+1); sh.getRange(row,1).setValue(new Date()); }
-  if (obj.title) sh.getRange(row, headers.title).setValue(obj.title);
-  if (obj.sku)   sh.getRange(row, headers.sku).setValue(String(obj.sku).toUpperCase());
-  if (obj.photos) sh.getRange(row, headers.photos).setValue(Array.isArray(obj.photos)? obj.photos.join("\n"): obj.photos);
-  if (obj.category) sh.getRange(row, headers.category).setValue(obj.category);
-  if (obj.brand) sh.getRange(row, headers.brand).setValue(obj.brand);
-  if (obj.size) sh.getRange(row, headers.size).setValue(obj.size);
-  if (obj.condition) sh.getRange(row, headers.condition).setValue(obj.condition);
-  if (obj.platform) sh.getRange(row, headers.platform).setValue(obj.platform);
+  if (!row) {
+    row = Math.max(2, last + 1);
+  }
+
+  const width = Math.max(15, sh.getLastColumn());
+  const current = sh.getRange(row, 1, 1, width).getValues()[0];
+  if (!current[0]) {
+    current[0] = new Date();
+  }
+  if (obj.sku) {
+    current[headers.sku - 1] = String(obj.sku).toUpperCase();
+  }
+  if (obj.title) {
+    current[headers.title - 1] = obj.title;
+  }
+  if (obj.photos) {
+    current[headers.photos - 1] = Array.isArray(obj.photos) ? obj.photos.join('\n') : obj.photos;
+  }
+  if (obj.category) {
+    current[headers.category - 1] = obj.category;
+  }
+  if (obj.brand) {
+    current[headers.brand - 1] = obj.brand;
+  }
+  if (obj.size) {
+    current[headers.size - 1] = obj.size;
+  }
+  if (obj.condition) {
+    current[headers.condition - 1] = obj.condition;
+  }
+  if (obj.platform) {
+    current[headers.platform - 1] = obj.platform;
+  }
+
+  sh.getRange(row, 1, 1, width).setValues([current]);
 }
 
 // ---- VENTES ----
-function ingestSales(){
-  const L = labels_();
-  const map = [
-    {label:L.SALES_VINTED, platform:"Vinted"},
-    {label:L.SALES_VESTIAIRE, platform:"Vestiaire"},
-    {label:L.SALES_EBAY, platform:"eBay"},
-    {label:L.SALES_LEBONCOIN, platform:"Leboncoin"},
-    {label:L.SALES_WHATNOT, platform:"Whatnot"},
-  ];
-  const labelDone = GmailApp.getUserLabelByName("Traite") || GmailApp.createLabel("Traite");
-  const labelErr  = GmailApp.getUserLabelByName("Erreur") || GmailApp.createLabel("Erreur");
-  const ss = SpreadsheetApp.getActive();
-  const sh = ss.getSheetByName("Ventes");
-  for (let {label, platform} of map){
-    const threads = GmailApp.search('label:"'+label+'" -label:Traite -label:Erreur', 0, 50);
-    for (let t of threads){
-      for (let m of t.getMessages()){
-        const parsed = parseSaleMessage_(platform, m);
-        if (!parsed) continue;
-        try {
-          insertSale_(sh, parsed.data);
-          t.addLabel(labelDone);
-          markProcessed_("INFO","ingestSales","OK", "", parsed.id);
-        } catch(e){
-          t.addLabel(labelErr);
-          markProcessed_("ERROR","ingestSales","KO", String(e), parsed.id);
-        }
-      }
+function ingestSales() {
+  console.time('ingestSales');
+  try {
+    const L = labels_();
+    const map = [
+      { label: L.SALES_VINTED, platform: 'Vinted' },
+      { label: L.SALES_VESTIAIRE, platform: 'Vestiaire' },
+      { label: L.SALES_EBAY, platform: 'eBay' },
+      { label: L.SALES_LEBONCOIN, platform: 'Leboncoin' },
+      { label: L.SALES_WHATNOT, platform: 'Whatnot' }
+    ];
+    const labelDone = ensureLabel_(DEFAULT_LABEL_DONE);
+    const labelErr = ensureLabel_(DEFAULT_LABEL_ERROR);
+    const ss = SpreadsheetApp.getActive();
+    const sh = ss.getSheetByName(SALES_SHEET_NAME);
+    if (!sh) {
+      return;
     }
+
+    map.forEach(({ label, platform }) => {
+      const threads = searchThreads_('label:"' + label + '" -label:' + DEFAULT_LABEL_DONE + ' -label:' + DEFAULT_LABEL_ERROR, 0, 50);
+      threads.forEach(thread => {
+        const msgs = threadMessages_(thread);
+        msgs.forEach(msg => {
+          const parsed = parseSaleMessage_(platform, msg);
+          if (!parsed) {
+            return;
+          }
+          try {
+            insertSale_(sh, parsed.data);
+            threadAddLabel_(thread, labelDone);
+            markProcessed_('INFO', 'ingestSales', 'OK', '', parsed.id);
+          } catch (err) {
+            threadAddLabel_(thread, labelErr);
+            markProcessed_('ERROR', 'ingestSales', 'KO', String(err), parsed.id);
+          }
+        });
+      });
+    });
+  } finally {
+    console.timeEnd('ingestSales');
   }
 }
 
-function insertSale_(sh, d){
-  const conf = getConfig_();
-  const pct = Number(conf['COMMISSION_'+d.platform.toUpperCase()]||0);
+function insertSale_(sh, d) {
+  const conf = typeof getConfig_ === 'function' ? getConfig_() : {};
+  const pctKey = 'COMMISSION_' + String(d.platform || '').toUpperCase();
+  const pct = Number(conf[pctKey] || 0);
   const last = sh.getLastRow();
-  const row = Math.max(2, last+1);
-  sh.getRange(row,1).setValue(new Date());
-  sh.getRange(row,2).setValue(d.platform);
-  sh.getRange(row,3).setValue(d.title);
-  sh.getRange(row,4).setValue(d.price);
-  sh.getRange(row,5).setValue(d.price*pct); // commission simple (étape 5)
-  sh.getRange(row,8).setValue(d.sku||"");
+  const row = Math.max(2, last + 1);
+  const width = Math.max(10, sh.getLastColumn());
+  const values = new Array(width).fill('');
+  values[0] = new Date();
+  values[1] = d.platform;
+  values[2] = d.title;
+  values[3] = d.price;
+  values[4] = d.price * pct;
+  values[7] = d.sku || '';
+  sh.getRange(row, 1, 1, width).setValues([values]);
 }
 
 // ---- FAVORIS & OFFRES Vinted ----
-function ingestFavsOffersVinted(){
-  const L = labels_();
-  const defs = [
-    {label:L.FAV_VINTED, type:"fav"},
-    {label:L.OFF_VINTED, type:"offer"}
-  ];
-  const labelDone = GmailApp.getUserLabelByName("Traite") || GmailApp.createLabel("Traite");
-  const labelErr  = GmailApp.getUserLabelByName("Erreur") || GmailApp.createLabel("Erreur");
-  const ss = SpreadsheetApp.getActive();
-  const sh = ss.getSheetByName("Stock");
-  for (let {label,type} of defs){
-    const threads = GmailApp.search('label:"'+label+'" -label:Traite -label:Erreur',0,50);
-    for (let t of threads){
-      for (let m of t.getMessages()){
-        const parsed = parseFavOfferMessage_(type, m);
-        if (!parsed) continue;
-        try {
-          bumpCounter_(sh, parsed.data);
-          t.addLabel(labelDone);
-          markProcessed_("INFO","ingestFavOffer","OK","", parsed.id);
-        } catch(e){
-          t.addLabel(labelErr);
-          markProcessed_("ERROR","ingestFavOffer","KO", String(e), parsed.id);
-        }
-      }
+function ingestFavsOffersVinted() {
+  console.time('ingestFavsOffersVinted');
+  try {
+    const L = labels_();
+    const defs = [
+      { label: L.FAV_VINTED, type: 'fav' },
+      { label: L.OFF_VINTED, type: 'offer' }
+    ];
+    const labelDone = ensureLabel_(DEFAULT_LABEL_DONE);
+    const labelErr = ensureLabel_(DEFAULT_LABEL_ERROR);
+    const ss = SpreadsheetApp.getActive();
+    const sh = ss.getSheetByName(STOCK_SHEET_NAME);
+    if (!sh) {
+      return;
     }
+
+    defs.forEach(({ label, type }) => {
+      const threads = searchThreads_('label:"' + label + '" -label:' + DEFAULT_LABEL_DONE + ' -label:' + DEFAULT_LABEL_ERROR, 0, 50);
+      threads.forEach(thread => {
+        const msgs = threadMessages_(thread);
+        msgs.forEach(msg => {
+          const parsed = parseFavOfferMessage_(type, msg);
+          if (!parsed) {
+            return;
+          }
+          try {
+            bumpCounter_(sh, parsed.data);
+            threadAddLabel_(thread, labelDone);
+            markProcessed_('INFO', 'ingestFavOffer', 'OK', '', parsed.id);
+          } catch (err) {
+            threadAddLabel_(thread, labelErr);
+            markProcessed_('ERROR', 'ingestFavOffer', 'KO', String(err), parsed.id);
+          }
+        });
+      });
+    });
+  } finally {
+    console.timeEnd('ingestFavsOffersVinted');
   }
 }
 
-function bumpCounter_(sh, d){
+function bumpCounter_(sh, d) {
   const last = sh.getLastRow();
-  if (last<2) return;
-  const rng = sh.getRange(2,2,last-1,1).getValues(); // SKU col B
+  if (last < 2) {
+    return;
+  }
+  const rng = sh.getRange(2, 2, last - 1, 1).getValues();
   let row = 0;
-  for (let i=0;i<rng.length;i++){ if (String(rng[i][0]).toUpperCase()===String(d.sku).toUpperCase()){ row=i+2; break; } }
-  if (!row) return; // SKU inconnu: ignoré en étape 5
-  const col = (d.type==='fav') ? 14 : 15; // Favoris/Offres
-  const old = Number(sh.getRange(row,col).getValue()||0);
-  sh.getRange(row,col).setValue(old+1);
+  for (let i = 0; i < rng.length; i++) {
+    if (String(rng[i][0]).toUpperCase() === String(d.sku).toUpperCase()) {
+      row = i + 2;
+      break;
+    }
+  }
+  if (!row) {
+    return;
+  }
+  const col = d.type === 'fav' ? 14 : 15;
+  const current = Number(sh.getRange(row, col).getValue() || 0);
+  sh.getRange(row, col, 1, 1).setValues([[current + 1]]);
 }
 
 // ---- ACHATS Vinted ----
-function ingestPurchasesVinted(){
-  const label = labels_().PUR_VINTED;
-  const threads = GmailApp.search('label:"'+label+'" -label:Traite -label:Erreur',0,50);
-  const labelDone = GmailApp.getUserLabelByName("Traite") || GmailApp.createLabel("Traite");
-  const labelErr  = GmailApp.getUserLabelByName("Erreur") || GmailApp.createLabel("Erreur");
-  const ss = SpreadsheetApp.getActive();
-  const sh = ss.getSheetByName("Achats");
-  for (let t of threads){
-    for (let m of t.getMessages()){
-      const parsed = parsePurchaseVinted_(m);
-      if (!parsed) continue;
-      try {
-        const row = Math.max(2, sh.getLastRow()+1);
-        sh.getRange(row,1).setValue(parsed.data.date);
-        sh.getRange(row,2).setValue(parsed.data.fournisseur);
-        sh.getRange(row,3).setValue(parsed.data.price);
-        sh.getRange(row,5).setValue(parsed.data.brand);
-        sh.getRange(row,6).setValue(parsed.data.size);
-        t.addLabel(labelDone);
-        markProcessed_("INFO","ingestPurchases","OK","", parsed.id);
-      } catch(e){
-        t.addLabel(labelErr);
-        markProcessed_("ERROR","ingestPurchases","KO", String(e), parsed.id);
-      }
+function ingestPurchasesVinted() {
+  console.time('ingestPurchasesVinted');
+  try {
+    const label = labels_().PUR_VINTED;
+    const threads = searchThreads_('label:"' + label + '" -label:' + DEFAULT_LABEL_DONE + ' -label:' + DEFAULT_LABEL_ERROR, 0, 50);
+    if (!threads.length) {
+      return;
     }
+    const labelDone = ensureLabel_(DEFAULT_LABEL_DONE);
+    const labelErr = ensureLabel_(DEFAULT_LABEL_ERROR);
+    const ss = SpreadsheetApp.getActive();
+    const sh = ss.getSheetByName(PURCHASES_SHEET_NAME);
+    if (!sh) {
+      return;
+    }
+
+    threads.forEach(thread => {
+      const msgs = threadMessages_(thread);
+      msgs.forEach(msg => {
+        const parsed = parsePurchaseVinted_(msg);
+        if (!parsed) {
+          return;
+        }
+        try {
+          const last = sh.getLastRow();
+          const row = Math.max(2, last + 1);
+          const width = Math.max(6, sh.getLastColumn());
+          const values = new Array(width).fill('');
+          values[0] = parsed.data.date;
+          values[1] = parsed.data.fournisseur;
+          values[2] = parsed.data.price;
+          values[4] = parsed.data.brand;
+          values[5] = parsed.data.size;
+          sh.getRange(row, 1, 1, width).setValues([values]);
+          threadAddLabel_(thread, labelDone);
+          markProcessed_('INFO', 'ingestPurchases', 'OK', '', parsed.id);
+        } catch (err) {
+          threadAddLabel_(thread, labelErr);
+          markProcessed_('ERROR', 'ingestPurchases', 'KO', String(err), parsed.id);
+        }
+      });
+    });
+  } finally {
+    console.timeEnd('ingestPurchasesVinted');
   }
 }

--- a/Gmail_Ingest_Run_Optimized.gs
+++ b/Gmail_Ingest_Run_Optimized.gs
@@ -6,56 +6,61 @@
  * Effets de bord: met à jour labels, remplit les feuilles, persiste des curseurs/procIds dans l'état utilisateur.
  * Pièges: veillez à purger les caches via step10ClearCaches(), quotas Gmail/UrlFetch selon volume, complexité accrue de pagination.
  * MAJ: 2025-09-26 – Codex Audit
- */
-/**
- * Étape 10 — Ingestion optimisée (batch + cache + idempotence rapide)
- * - Ne touche pas à tes anciens parseurs: on réutilise parseStockJsonMessage_, parseSaleMessage_, etc.
- * - Idempotence: on garde un set d'IDs déjà traités dans UserProperties (PROC_IDS) + Logs (fallback).
+ * @change: instrumentation console.time, backoff partagé et utilisation des helpers batch pour les écritures.
  */
 
-function ingestAllLabelsFast(){
-  const L = labels_();
-  // Ordre conseillé: JSON Stock -> Ventes -> Achats -> Favoris/Offres
-  ingestStockJsonFast_(L.INGEST_STOCK);
-  ingestSalesFast_([
-    {label:L.SALES_VINTED,      platform:"Vinted"},
-    {label:L.SALES_VESTIAIRE,   platform:"Vestiaire"},
-    {label:L.SALES_EBAY,        platform:"eBay"},
-    {label:L.SALES_LEBONCOIN,   platform:"Leboncoin"},
-    {label:L.SALES_WHATNOT,     platform:"Whatnot"},
-  ]);
-  ingestPurchasesVintedFast_(L.PUR_VINTED);
-  ingestFavsOffersFast_([{label:L.FAV_VINTED,type:"fav"},{label:L.OFF_VINTED,type:"offer"}]);
-  logE_("INFO","IngestFast","Terminé","");
+function ingestAllLabelsFast() {
+  console.time('ingestAllLabelsFast');
+  try {
+    const L = labels_();
+    ingestStockJsonFast_(L.INGEST_STOCK);
+    ingestSalesFast_([
+      { label: L.SALES_VINTED, platform: 'Vinted' },
+      { label: L.SALES_VESTIAIRE, platform: 'Vestiaire' },
+      { label: L.SALES_EBAY, platform: 'eBay' },
+      { label: L.SALES_LEBONCOIN, platform: 'Leboncoin' },
+      { label: L.SALES_WHATNOT, platform: 'Whatnot' }
+    ]);
+    ingestPurchasesVintedFast_(L.PUR_VINTED);
+    ingestFavsOffersFast_([
+      { label: L.FAV_VINTED, type: 'fav' },
+      { label: L.OFF_VINTED, type: 'offer' }
+    ]);
+    logE_('INFO', 'IngestFast', 'Terminé', '');
+  } finally {
+    console.timeEnd('ingestAllLabelsFast');
+  }
 }
 
 // --- Proc IDs (idempotence mémoire + persistance légère) ---
-const PROC_IDS_FAST_KEY = "PROC_IDS";
+const PROC_IDS_FAST_KEY = 'PROC_IDS';
 let PROC_IDS_FAST_CACHE = null;
 
-function getProcIds_(){
+function getProcIds_() {
   if (!PROC_IDS_FAST_CACHE) {
     PROC_IDS_FAST_CACHE = stateGet_(PROC_IDS_FAST_KEY, {}) || {};
   }
   return PROC_IDS_FAST_CACHE;
 }
-function addProcId_(id){
+
+function addProcId_(id) {
   if (!id) return;
   const map = getProcIds_();
   map[id] = Date.now();
   pruneProcIdsFast_(map);
   statePut_(PROC_IDS_FAST_KEY, map);
 }
-function seenProcId_(id){
+
+function seenProcId_(id) {
   const map = getProcIds_();
   return !!map[id];
 }
 
-function pruneProcIdsFast_(map){
+function pruneProcIdsFast_(map) {
   const keys = Object.keys(map);
   const LIMIT = 500;
   if (keys.length <= LIMIT) return;
-  keys.sort((a,b) => Number(map[a] || 0) - Number(map[b] || 0));
+  keys.sort((a, b) => Number(map[a] || 0) - Number(map[b] || 0));
   while (keys.length > LIMIT) {
     const key = keys.shift();
     delete map[key];
@@ -63,8 +68,8 @@ function pruneProcIdsFast_(map){
 }
 
 // --- Pagination threads (curseur en state) ---
-function nextThreads_(query, batchSize){
-  const cursorKey = "THREAD_CURSOR::"+query;
+function nextThreads_(query, batchSize) {
+  const cursorKey = 'THREAD_CURSOR::' + query;
   const now = Date.now();
   let cursor = stateGet_(cursorKey, null);
   if (typeof cursor === 'number') {
@@ -80,7 +85,7 @@ function nextThreads_(query, batchSize){
   }
 
   const page = cursor.page || 0;
-  const threads = withBackoff_(() => GmailApp.search(query, page * batchSize, batchSize));
+  const threads = searchThreads_(query, page * batchSize, batchSize);
   if (threads.length === 0) {
     stateDel_(cursorKey);
     return [];
@@ -92,35 +97,176 @@ function nextThreads_(query, batchSize){
 }
 
 // ========== STOCK JSON ==========
-function ingestStockJsonFast_(label){
-  const done = GmailApp.getUserLabelByName("Traite") || GmailApp.createLabel("Traite");
-  const err  = GmailApp.getUserLabelByName("Erreur") || GmailApp.createLabel("Erreur");
-  const ss = SpreadsheetApp.getActive(), sh = ss.getSheetByName("Stock");
-  const query = 'label:"'+label+'" -label:Traite -label:Erreur';
-  let threads;
-
-  while ((threads = nextThreads_(query, 25)).length) {
-    for (const t of threads) {
-      const msgs = t.getMessages();
-      for (const m of msgs) {
-        const id = m.getId();
-        if (seenProcId_(id)) continue;
-
-        const parsed = parseStockJsonMessage_(m);
-        if (!parsed) { 
-          addProcId_(id); 
-          continue; 
-        }
-
-        try {
-          upsertStock_(sh, parsed.data);
-          t.addLabel(done);
-          addProcId_(id);
-        } catch (e){
-          t.addLabel(err);
-          logE_("ERROR","ingestStockJsonFast", String(e), id);
+function ingestStockJsonFast_(label) {
+  console.time('ingestStockJsonFast');
+  try {
+    const done = ensureLabel_(DEFAULT_LABEL_DONE);
+    const err = ensureLabel_(DEFAULT_LABEL_ERROR);
+    const ss = SpreadsheetApp.getActive();
+    const sh = ss.getSheetByName(STOCK_SHEET_NAME);
+    if (!sh) {
+      return;
+    }
+    const query = 'label:"' + label + '" -label:' + DEFAULT_LABEL_DONE + ' -label:' + DEFAULT_LABEL_ERROR;
+    let threads;
+    while ((threads = nextThreads_(query, 25)).length) {
+      for (const t of threads) {
+        const msgs = threadMessages_(t);
+        for (const m of msgs) {
+          const id = m.getId();
+          if (seenProcId_(id)) continue;
+          const parsed = parseStockJsonMessage_(m);
+          if (!parsed) {
+            addProcId_(id);
+            continue;
+          }
+          try {
+            upsertStock_(sh, parsed.data);
+            threadAddLabel_(t, done);
+            addProcId_(id);
+          } catch (e) {
+            threadAddLabel_(t, err);
+            logE_('ERROR', 'ingestStockJsonFast', String(e), id);
+          }
         }
       }
     }
+  } finally {
+    console.timeEnd('ingestStockJsonFast');
+  }
+}
+
+// ========== VENTES ==========
+function ingestSalesFast_(defs) {
+  console.time('ingestSalesFast');
+  try {
+    const done = ensureLabel_(DEFAULT_LABEL_DONE);
+    const err = ensureLabel_(DEFAULT_LABEL_ERROR);
+    const ss = SpreadsheetApp.getActive();
+    const sh = ss.getSheetByName(SALES_SHEET_NAME);
+    if (!sh) {
+      return;
+    }
+
+    defs.forEach(({ label, platform }) => {
+      const query = 'label:"' + label + '" -label:' + DEFAULT_LABEL_DONE + ' -label:' + DEFAULT_LABEL_ERROR;
+      let threads;
+      while ((threads = nextThreads_(query, 20)).length) {
+        for (const t of threads) {
+          const msgs = threadMessages_(t);
+          for (const m of msgs) {
+            const id = m.getId();
+            if (seenProcId_(id)) continue;
+            const parsed = parseSaleMessage_(platform, m);
+            if (!parsed) {
+              addProcId_(id);
+              continue;
+            }
+            try {
+              insertSale_(sh, parsed.data);
+              threadAddLabel_(t, done);
+              addProcId_(id);
+            } catch (e) {
+              threadAddLabel_(t, err);
+              logE_('ERROR', 'ingestSalesFast', String(e), id);
+            }
+          }
+        }
+      }
+    });
+  } finally {
+    console.timeEnd('ingestSalesFast');
+  }
+}
+
+// ========== ACHATS ==========
+function ingestPurchasesVintedFast_(label) {
+  console.time('ingestPurchasesVintedFast');
+  try {
+    const done = ensureLabel_(DEFAULT_LABEL_DONE);
+    const err = ensureLabel_(DEFAULT_LABEL_ERROR);
+    const ss = SpreadsheetApp.getActive();
+    const sh = ss.getSheetByName(PURCHASES_SHEET_NAME);
+    if (!sh) {
+      return;
+    }
+    const query = 'label:"' + label + '" -label:' + DEFAULT_LABEL_DONE + ' -label:' + DEFAULT_LABEL_ERROR;
+    let threads;
+    while ((threads = nextThreads_(query, 20)).length) {
+      for (const t of threads) {
+        const msgs = threadMessages_(t);
+        for (const m of msgs) {
+          const id = m.getId();
+          if (seenProcId_(id)) continue;
+          const parsed = parsePurchaseVinted_(m);
+          if (!parsed) {
+            addProcId_(id);
+            continue;
+          }
+          try {
+            const last = sh.getLastRow();
+            const row = Math.max(2, last + 1);
+            const width = Math.max(6, sh.getLastColumn());
+            const values = new Array(width).fill('');
+            values[0] = parsed.data.date;
+            values[1] = parsed.data.fournisseur;
+            values[2] = parsed.data.price;
+            values[4] = parsed.data.brand;
+            values[5] = parsed.data.size;
+            sh.getRange(row, 1, 1, width).setValues([values]);
+            threadAddLabel_(t, done);
+            addProcId_(id);
+          } catch (e) {
+            threadAddLabel_(t, err);
+            logE_('ERROR', 'ingestPurchasesFast', String(e), id);
+          }
+        }
+      }
+    }
+  } finally {
+    console.timeEnd('ingestPurchasesVintedFast');
+  }
+}
+
+// ========== FAVORIS / OFFRES ==========
+function ingestFavsOffersFast_(defs) {
+  console.time('ingestFavsOffersFast');
+  try {
+    const done = ensureLabel_(DEFAULT_LABEL_DONE);
+    const err = ensureLabel_(DEFAULT_LABEL_ERROR);
+    const ss = SpreadsheetApp.getActive();
+    const sh = ss.getSheetByName(STOCK_SHEET_NAME);
+    if (!sh) {
+      return;
+    }
+
+    defs.forEach(({ label, type }) => {
+      const query = 'label:"' + label + '" -label:' + DEFAULT_LABEL_DONE + ' -label:' + DEFAULT_LABEL_ERROR;
+      let threads;
+      while ((threads = nextThreads_(query, 20)).length) {
+        for (const t of threads) {
+          const msgs = threadMessages_(t);
+          for (const m of msgs) {
+            const id = m.getId();
+            if (seenProcId_(id)) continue;
+            const parsed = parseFavOfferMessage_(type, m);
+            if (!parsed) {
+              addProcId_(id);
+              continue;
+            }
+            try {
+              bumpCounter_(sh, parsed.data);
+              threadAddLabel_(t, done);
+              addProcId_(id);
+            } catch (e) {
+              threadAddLabel_(t, err);
+              logE_('ERROR', 'ingestFavOfferFast', String(e), id);
+            }
+          }
+        }
+      }
+    });
+  } finally {
+    console.timeEnd('ingestFavsOffersFast');
   }
 }

--- a/PerfendPoints.gs
+++ b/PerfendPoints.gs
@@ -1,109 +1,208 @@
 /**
  * Module: PerfendPoints
  * Rôle: version performante des endpoints UI (bootstrap JSON, caches multi-niveaux, diagnostics).
- * Entrées publiques: openCRM(), ui_getDashboard(), ui_getStockAll(), ui_getVentesAll(), ui_getConfig(), ui_getLogsTail(), ui_step3RefreshRefs(), ui_step8RecalcAll(), ui_saveConfig(), ui_ingestFast(), purge*(), cronRecomputeBootstrap(), setupTriggers().
+ * Entrées publiques: openCRM(), ui_getDashboard(), ui_getStockAll(), ui_getVentesAll(), ui_getConfig(), ui_saveConfig(), ui_ingestFast(), ui_step3RefreshRefs(), ui_step8RecalcAll(), purge*(), cronRecomputeBootstrap(), setupTriggers().
  * Dépendances: CacheService (script/document), PropertiesService, SpreadsheetApp (feuilles), HtmlService (Index), Step3/Step8/Ui_Config helpers, timed().
  * Effets de bord: remplit caches chauds, écrit dans Properties, ouvre modales, peut modifier caches en enveloppant les fonctions existantes.
  * Pièges: duplication d'endpoints avec Ui_Server (risque conflits), invalidation manuelle nécessaire après modifications, attention aux quotas lors du bootstrap complet.
  * MAJ: 2025-09-26 – Codex Audit
+ * @change: centralisation des endpoints UI, ajout du backoff partagé et invalidations explicites des caches.
  */
+
 // ===== PerfEndpoints.gs — Full preload + multi-cache + diag =====
 
 // --- Clés de cache
-const BOOTSTRAP_KEY         = 'BOOTSTRAP_JSON_v1';
-const BOOTSTRAP_CACHE_KEY   = 'cache:bootstrap_json:v1';
-const DASHBOARD_CACHE_KEY   = 'cache:dashboard:v1';
-const STOCK_CACHE_KEY       = 'cache:stock_all:v1';
-const VENTES_CACHE_KEY      = 'cache:ventes_all:v1';
+const BOOTSTRAP_KEY = 'BOOTSTRAP_JSON_v1';
+const BOOTSTRAP_CACHE_KEY = 'cache:bootstrap_json:v1';
+const DASHBOARD_CACHE_KEY = 'cache:dashboard:v1';
+const STOCK_CACHE_KEY = 'cache:stock_all:v1';
+const VENTES_CACHE_KEY = 'cache:ventes_all:v1';
 
 // --- TTL (secondes)
-const HOT_TTL   = 120;   // ScriptCache (chaud, super-rapide)
-const WARM_TTL  = 600;   // DocumentCache (chaud 10 min)
-const PROP_TTL  = 0;     // Properties (pas de TTL; persistant)
+const HOT_TTL = 120; // ScriptCache (chaud, super-rapide)
+const WARM_TTL = 600; // DocumentCache (chaud 10 min)
+const PROP_TTL = 0; // Properties (pas de TTL; persistant)
 
-// --- Entetes de colonnes attendues
-const STOCK_HEADERS  = ['Date entree','SKU','Titre','Photos','Categorie','Marque','Taille','Etat','Prix achat (link)','Statut','Plateforme','Ref Achat','Favoris','Offres','Notes'];
-const VENTES_HEADERS = ['Date','Plateforme','Titre','Prix','Frais/Comm','Frais port','Acheteur','SKU','Marge brute','Marge nette'];
+// --- Entêtes de colonnes attendues
+const STOCK_HEADERS = ['Date entree', 'SKU', 'Titre', 'Photos', 'Categorie', 'Marque', 'Taille', 'Etat', 'Prix achat (link)', 'Statut', 'Plateforme', 'Ref Achat', 'Favoris', 'Offres', 'Notes'];
+const VENTES_HEADERS = ['Date', 'Plateforme', 'Titre', 'Prix', 'Frais/Comm', 'Frais port', 'Acheteur', 'SKU', 'Marge brute', 'Marge nette'];
+
+const BACKOFF_DEFAULT = { retries: 5, baseMs: 200, factor: 2 };
 
 /* ======================= Utils ======================= */
+/**
+ * Mesure l'exécution d'une fonction (console.log millisecondes).
+ * @param {string} label
+ * @param {function():*} fn
+ * @return {*}
+ */
 function timed(label, fn) {
   const t0 = Date.now();
-  try { return fn(); }
-  finally { console.log('[perf]', label, 'ms=', (Date.now() - t0)); }
+  try {
+    return fn();
+  } finally {
+    console.log('[perf]', label, 'ms=', Date.now() - t0);
+  }
 }
-function hotCache(){ try { return CacheService.getScriptCache(); } catch(_) { return null; } }
-function warmCache(){ try { return CacheService.getDocumentCache(); } catch(_) { return null; } }
 
-function cacheGetStr_(key){
-  const hot = hotCache(); if (hot){ const v = hot.get(key); if (v!=null) return v; }
-  const warm = warmCache(); if (warm){ const v = warm.get(key); if (v!=null){ if (hot) hot.put(key, v, HOT_TTL); return v; } }
+/**
+ * Exécute une fonction avec backoff exponentiel.
+ * @param {function():*} fn
+ * @param {{retries:number, baseMs:number, factor:number}=} options
+ * @return {*}
+ */
+function withBackoff_(fn, options) {
+  const cfg = Object.assign({}, BACKOFF_DEFAULT, options || {});
+  let attempt = 0;
+  while (true) { // eslint-disable-line no-constant-condition
+    try {
+      return fn();
+    } catch (err) {
+      attempt += 1;
+      if (attempt > cfg.retries) {
+        console.error('withBackoff_: abandon après', attempt, 'tentatives');
+        throw err;
+      }
+      const delay = Math.min(cfg.baseMs * Math.pow(cfg.factor, attempt - 1), 30000);
+      console.warn('withBackoff_: tentative', attempt, 'échec -> sleep', delay, 'ms');
+      Utilities.sleep(delay + Math.floor(Math.random() * 50));
+    }
+  }
+}
+
+function hotCache() {
+  try {
+    return CacheService.getScriptCache();
+  } catch (_err) {
+    return null;
+  }
+}
+
+function warmCache() {
+  try {
+    return CacheService.getDocumentCache();
+  } catch (_err) {
+    return null;
+  }
+}
+
+function cacheGetStr_(key) {
+  const hot = hotCache();
+  if (hot) {
+    const hit = hot.get(key);
+    if (hit != null) {
+      return hit;
+    }
+  }
+  const warm = warmCache();
+  if (warm) {
+    const hit = warm.get(key);
+    if (hit != null) {
+      if (hot) {
+        hot.put(key, hit, HOT_TTL);
+      }
+      return hit;
+    }
+  }
   return null;
 }
-function cachePutStr_(key, value){
-  if (typeof value !== 'string') return;
-  const hot = hotCache();  if (hot)  hot.put(key, value, HOT_TTL);
-  const warm = warmCache();if (warm) warm.put(key, value, WARM_TTL);
+
+function cachePutStr_(key, value) {
+  if (typeof value !== 'string') {
+    return;
+  }
+  const hot = hotCache();
+  if (hot) {
+    hot.put(key, value, HOT_TTL);
+  }
+  const warm = warmCache();
+  if (warm) {
+    warm.put(key, value, WARM_TTL);
+  }
 }
-function cacheDel_(key){
-  const hot = hotCache();  if (hot)  try{ hot.remove(key); }catch(_) {}
-  const warm = warmCache();if (warm) try{ warm.remove(key); }catch(_) {}
+
+function cacheDel_(key) {
+  const hot = hotCache();
+  if (hot) {
+    try {
+      hot.remove(key);
+    } catch (_err) {
+      // ignore
+    }
+  }
+  const warm = warmCache();
+  if (warm) {
+    try {
+      warm.remove(key);
+    } catch (_err) {
+      // ignore
+    }
+  }
 }
-function jsonGet_(key){
-  const s = cacheGetStr_(key);
-  if (s) { try { return JSON.parse(s); } catch(_) { cacheDel_(key); } }
+
+function jsonGet_(key) {
+  const raw = cacheGetStr_(key);
+  if (raw) {
+    try {
+      return JSON.parse(raw);
+    } catch (_err) {
+      cacheDel_(key);
+    }
+  }
   return null;
 }
-function jsonPut_(key, obj){ try { cachePutStr_(key, JSON.stringify(obj)); } catch(_) {} }
+
+function jsonPut_(key, obj) {
+  try {
+    cachePutStr_(key, JSON.stringify(obj));
+  } catch (_err) {
+    // JSON stringify échoué -> ignorer
+  }
+}
 
 function makePicker_(headers, wanted) {
-  // Normalise accents de base (Stock headers doivent etre FR mais sans accent pour robustesse)
-  const norm = s => String(s||'').toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g,'').trim();
-  const map = wanted.map(w => {
-    const target = norm(w);
-    const idx = headers.findIndex(h => norm(h) === target);
-    return idx;
+  const norm = s => String(s || '').toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '').trim();
+  const indexes = wanted.map(target => {
+    const normalized = norm(target);
+    return headers.findIndex(h => norm(h) === normalized);
   });
-  return row => wanted.map((_, i) => (map[i] >= 0 ? row[map[i]] : ''));
+  return row => wanted.map((_, i) => (indexes[i] >= 0 ? row[indexes[i]] : ''));
 }
 
 /* ======================= UI / HTML ======================= */
 function openCRM() {
   const html = buildUiHtml_()
     .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL)
-    .setWidth(1200).setHeight(700);
+    .setWidth(1200)
+    .setHeight(700);
   SpreadsheetApp.getUi().showModalDialog(html, '🚀 CRM - Interface Principale');
 }
 
 function buildUiHtml_() {
-  // On lit le bootstrap JSON (chaine) puis on sanitise les ellipses si jamais
-  const raw = getBootstrapJson_(); // string ou 'null'
-  const safe = (typeof raw === 'string' && raw.length)
-    ? raw.replace(/\u2026/g, '...')
-    : 'null';
-
-  const t = HtmlService.createTemplateFromFile('Index');
-  t.BOOTSTRAP_JSON = safe; // injecte tel quel (UNESCAPED dans Index)
-
-  return t.evaluate()
+  const raw = getBootstrapJson_();
+  const safe = typeof raw === 'string' && raw.length ? raw.replace(/\u2026/g, '...') : 'null';
+  const tpl = HtmlService.createTemplateFromFile('Index');
+  tpl.BOOTSTRAP_JSON = safe;
+  return tpl.evaluate()
     .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL)
-    .setWidth(1200).setHeight(700);
+    .setWidth(1200)
+    .setHeight(700);
 }
 
 /* ======================= Bootstrap ======================= */
 function getBootstrapJson_() {
-  // 1) caches
   const cached = cacheGetStr_(BOOTSTRAP_CACHE_KEY);
-  if (cached) return cached;
+  if (cached) {
+    return cached;
+  }
 
-  // 2) properties
   const props = PropertiesService.getDocumentProperties();
   const stored = props.getProperty(BOOTSTRAP_KEY);
-  if (stored){
+  if (stored) {
     cachePutStr_(BOOTSTRAP_CACHE_KEY, stored);
     return stored;
   }
 
-  // 3) compute
   const json = JSON.stringify(buildBootstrapPayload_());
   setBootstrapJson_(json);
   cachePutStr_(BOOTSTRAP_CACHE_KEY, json);
@@ -113,75 +212,91 @@ function getBootstrapJson_() {
 function setBootstrapJson_(json) {
   PropertiesService.getDocumentProperties().setProperty(BOOTSTRAP_KEY, json);
   cachePutStr_(BOOTSTRAP_CACHE_KEY, json);
-
-  // seed KPI cache
   try {
     const obj = JSON.parse(json);
     const kpis = Array.isArray(obj?.kpis) ? obj.kpis : [];
     jsonPut_(DASHBOARD_CACHE_KEY, { kpis: kpis });
-  } catch(e) {
-    console.warn('seed dashboard cache failed', e);
+  } catch (err) {
+    console.warn('seed dashboard cache failed', err);
   }
 }
 
 function buildBootstrapPayload_() {
-  const ss = SpreadsheetApp.getActive();
-
-  const kpis   = timed('bootstrap:dashboard', () => ui_getDashboard().kpis);
-  const stockR = timed('bootstrap:stock',     () => ui_getStockAll());
-  const ventR  = timed('bootstrap:ventes',    () => ui_getVentesAll());
-  const cfg    = timed('bootstrap:config',    () => ui_getConfig());
-  const logs   = timed('bootstrap:logs',      () => ui_getLogsTail(50));
+  const kpis = timed('bootstrap:dashboard', () => ui_getDashboard().kpis);
+  const stockR = timed('bootstrap:stock', () => ui_getStockAll());
+  const ventR = timed('bootstrap:ventes', () => ui_getVentesAll());
+  const cfg = timed('bootstrap:config', () => ui_getConfig());
+  const logs = timed('bootstrap:logs', () => ui_getLogsTail(50));
 
   return {
     ts: Date.now(),
     kpis: kpis,
-    stock:  { total: stockR.total, page1: stockR.rows, headers: stockR.headers },
-    ventes: { total: ventR.total,  page1: ventR.rows,  headers: ventR.headers  },
+    stock: { total: stockR.total, page1: stockR.rows, headers: stockR.headers },
+    ventes: { total: ventR.total, page1: ventR.rows, headers: ventR.headers },
     config: cfg,
     logs: logs
   };
 }
 
 /* ======================= Endpoints (avec cache) ======================= */
-// Dashboard
-function ui_getDashboard(){
+function ui_getDashboard() {
   return timed('ui_getDashboard', () => {
     const hit = jsonGet_(DASHBOARD_CACHE_KEY);
-    if (hit) return hit;
+    if (hit) {
+      return hit;
+    }
 
     const ss = SpreadsheetApp.getActive();
     const sh = ss.getSheetByName('Dashboard');
-    if (!sh) { const res = { kpis: [] }; jsonPut_(DASHBOARD_CACHE_KEY, res); return res; }
-
-    const vals = sh.getDataRange().getValues();
-    if (!vals || vals.length <= 1) { const res = { kpis: [] }; jsonPut_(DASHBOARD_CACHE_KEY, res); return res; }
-
-    const rows = [];
-    for (let i=1;i<vals.length;i++){
-      const k = vals[i][0];
-      if (k!=null && k!=='') rows.push([k, vals[i][1]]);
+    if (!sh) {
+      const resEmpty = { kpis: [] };
+      jsonPut_(DASHBOARD_CACHE_KEY, resEmpty);
+      return resEmpty;
     }
-    const res = { kpis: rows };
+
+    const values = sh.getDataRange().getValues();
+    if (!values || values.length <= 1) {
+      const resEmpty = { kpis: [] };
+      jsonPut_(DASHBOARD_CACHE_KEY, resEmpty);
+      return resEmpty;
+    }
+
+    const kpis = [];
+    for (let i = 1; i < values.length; i++) {
+      const key = values[i][0];
+      if (key != null && key !== '') {
+        kpis.push([key, values[i][1]]);
+      }
+    }
+    const res = { kpis: kpis };
     jsonPut_(DASHBOARD_CACHE_KEY, res);
     return res;
   });
 }
 
-// Stock (ALL)
-function ui_getStockAll(){
+function ui_getStockAll() {
   return timed('ui_getStockAll', () => {
     const hit = jsonGet_(STOCK_CACHE_KEY);
-    if (hit) return Object.assign({ headers: STOCK_HEADERS }, hit);
+    if (hit) {
+      return Object.assign({ headers: STOCK_HEADERS }, hit);
+    }
 
     const ss = SpreadsheetApp.getActive();
     const sh = ss.getSheetByName('Stock');
-    if (!sh) { const empty = { total: 0, rows: [], headers: STOCK_HEADERS }; jsonPut_(STOCK_CACHE_KEY, { total: 0, rows: [] }); return empty; }
+    if (!sh) {
+      const empty = { total: 0, rows: [], headers: STOCK_HEADERS };
+      jsonPut_(STOCK_CACHE_KEY, { total: 0, rows: [] });
+      return empty;
+    }
 
     const values = sh.getDataRange().getValues();
-    if (!values || values.length <= 1) { const empty = { total: 0, rows: [], headers: STOCK_HEADERS }; jsonPut_(STOCK_CACHE_KEY, { total: 0, rows: [] }); return empty; }
+    if (!values || values.length <= 1) {
+      const empty = { total: 0, rows: [], headers: STOCK_HEADERS };
+      jsonPut_(STOCK_CACHE_KEY, { total: 0, rows: [] });
+      return empty;
+    }
 
-    const headers = values[0].map(h => String(h||'').trim());
+    const headers = values[0].map(h => String(h || '').trim());
     const pick = makePicker_(headers, STOCK_HEADERS);
     const rows = values.slice(1).map(pick);
     const res = { total: rows.length, rows: rows };
@@ -190,20 +305,29 @@ function ui_getStockAll(){
   });
 }
 
-// Ventes (ALL)
-function ui_getVentesAll(){
+function ui_getVentesAll() {
   return timed('ui_getVentesAll', () => {
     const hit = jsonGet_(VENTES_CACHE_KEY);
-    if (hit) return Object.assign({ headers: VENTES_HEADERS }, hit);
+    if (hit) {
+      return Object.assign({ headers: VENTES_HEADERS }, hit);
+    }
 
     const ss = SpreadsheetApp.getActive();
     const sh = ss.getSheetByName('Ventes');
-    if (!sh) { const empty = { total: 0, rows: [], headers: VENTES_HEADERS }; jsonPut_(VENTES_CACHE_KEY, { total: 0, rows: [] }); return empty; }
+    if (!sh) {
+      const empty = { total: 0, rows: [], headers: VENTES_HEADERS };
+      jsonPut_(VENTES_CACHE_KEY, { total: 0, rows: [] });
+      return empty;
+    }
 
     const values = sh.getDataRange().getValues();
-    if (!values || values.length <= 1) { const empty = { total: 0, rows: [], headers: VENTES_HEADERS }; jsonPut_(VENTES_CACHE_KEY, { total: 0, rows: [] }); return empty; }
+    if (!values || values.length <= 1) {
+      const empty = { total: 0, rows: [], headers: VENTES_HEADERS };
+      jsonPut_(VENTES_CACHE_KEY, { total: 0, rows: [] });
+      return empty;
+    }
 
-    const headers = values[0].map(h => String(h||'').trim());
+    const headers = values[0].map(h => String(h || '').trim());
     const pick = makePicker_(headers, VENTES_HEADERS);
     const rows = values.slice(1).map(pick);
     const res = { total: rows.length, rows: rows };
@@ -212,48 +336,122 @@ function ui_getVentesAll(){
   });
 }
 
-// Config
-function ui_getConfig(){
+function ui_getConfig() {
   return timed('ui_getConfig', () => {
-    if (typeof getKnownConfig === 'function'){
-      try { return getKnownConfig(); } catch(e){ console.warn('getKnownConfig failed', e); }
+    if (typeof getConfiguration === 'function') {
+      try {
+        return getConfiguration();
+      } catch (err) {
+        console.warn('getConfiguration failed', err);
+      }
+    }
+    if (typeof getKnownConfig === 'function') {
+      try {
+        return getKnownConfig();
+      } catch (err) {
+        console.warn('getKnownConfig failed', err);
+      }
     }
     return [];
   });
 }
 
-// Logs tail
-function ui_getLogsTail(n){
+function ui_saveConfig(payload) {
+  return timed('ui_saveConfig', () => {
+    let result = null;
+    if (typeof saveConfiguration === 'function') {
+      result = saveConfiguration(payload);
+    } else if (typeof saveConfigValues === 'function') {
+      result = saveConfigValues(payload);
+    }
+    purgeBootstrapCaches_();
+    return result;
+  });
+}
+
+function ui_step3RefreshRefs() {
+  return timed('ui_step3RefreshRefs', () => {
+    if (typeof step3RefreshRefs === 'function') {
+      const res = step3RefreshRefs();
+      purgeStockCache();
+      purgeDashboardCache();
+      purgeBootstrapCaches_();
+      return res;
+    }
+    return null;
+  });
+}
+
+function ui_step8RecalcAll() {
+  return timed('ui_step8RecalcAll', () => {
+    if (typeof step8RecalcAll === 'function') {
+      const res = step8RecalcAll();
+      purgeVentesCache();
+      purgeDashboardCache();
+      purgeBootstrapCaches_();
+      return res;
+    }
+    return null;
+  });
+}
+
+function ui_ingestFast() {
+  return timed('ui_ingestFast', () => {
+    let res = null;
+    if (typeof ingestAllLabelsFast === 'function') {
+      res = ingestAllLabelsFast();
+    } else if (typeof ingestAllLabels === 'function') {
+      res = ingestAllLabels();
+    }
+    purgeStockCache();
+    purgeVentesCache();
+    purgeDashboardCache();
+    purgeBootstrapCaches_();
+    return res;
+  });
+}
+
+function ui_getLogsTail(n) {
   return timed('ui_getLogsTail', () => {
-    const take = Math.max(1, Number(n)||50);
+    const take = Math.max(1, Number(n) || 50);
     const ss = SpreadsheetApp.getActive();
     const sh = ss.getSheetByName('Logs');
-    if (!sh) return [];
+    if (!sh) {
+      return [];
+    }
     const last = sh.getLastRow();
-    if (last < 2) return [];
+    if (last < 2) {
+      return [];
+    }
     const count = Math.min(take, last - 1);
     const start = last - count + 1;
     return sh.getRange(start, 1, count, 5).getValues();
   });
 }
 
-/* ======================= Actions (si existantes) ======================= */
-function ui_step3RefreshRefs(){ return timed('ui_step3RefreshRefs', ()=> { if (typeof step3RefreshRefs==='function') return step3RefreshRefs(); }); }
-function ui_step8RecalcAll(){  return timed('ui_step8RecalcAll',  ()=> { if (typeof step8RecalcAll==='function')  return step8RecalcAll();  }); }
-function ui_saveConfig(rows){  return timed('ui_saveConfig',      ()=> { if (typeof saveConfig==='function')      return saveConfig(rows); }); }
-function ui_ingestFast(){      return timed('ui_ingestFast',      ()=> { if (typeof ingestFast==='function')      return ingestFast();      }); }
-
 /* ======================= Invalidation / Maintenance ======================= */
-// Purges fines (appelle-les apres une modif de donnees)
-function purgeDashboardCache(){ cacheDel_(DASHBOARD_CACHE_KEY); }
-function purgeStockCache(){     cacheDel_(STOCK_CACHE_KEY); }
-function purgeVentesCache(){    cacheDel_(VENTES_CACHE_KEY); }
-
-function purgeAllCaches(){
+function purgeDashboardCache() {
   cacheDel_(DASHBOARD_CACHE_KEY);
+}
+
+function purgeStockCache() {
   cacheDel_(STOCK_CACHE_KEY);
+}
+
+function purgeVentesCache() {
   cacheDel_(VENTES_CACHE_KEY);
+}
+
+function purgeBootstrapCaches_() {
   cacheDel_(BOOTSTRAP_CACHE_KEY);
+  PropertiesService.getDocumentProperties().deleteProperty(BOOTSTRAP_KEY);
+}
+
+function purgeAllCaches() {
+  purgeDashboardCache();
+  purgeStockCache();
+  purgeVentesCache();
+  purgeBootstrapCaches_();
 }
 
 function cronRecomputeBootstrap() {
@@ -261,63 +459,81 @@ function cronRecomputeBootstrap() {
     const json = JSON.stringify(buildBootstrapPayload_());
     setBootstrapJson_(json);
     purgeAllCaches();
-    // Re-seed caches chauds pour l'ouverture suivante
     cachePutStr_(BOOTSTRAP_CACHE_KEY, json);
     return { ok: true, ts: Date.now() };
   });
 }
 
 function setupTriggers() {
-  // Recompute bootstrap chaque heure
   ScriptApp.newTrigger('cronRecomputeBootstrap').timeBased().everyHours(1).create();
 }
 
 /* ======================= Helpers optionnels ======================= */
-function toNum_(v){ if (v==null || v==='') return 0; const n = Number(v); return isNaN(n) ? 0 : n; }
-function fmtEuro_(v){
-  const n = toNum_(v); if (!n) return '';
-  return Utilities.formatString('%s €', n.toLocaleString('fr-FR', {minimumFractionDigits:2, maximumFractionDigits:2}));
+function toNum_(v) {
+  if (v == null || v === '') {
+    return 0;
+  }
+  const n = Number(v);
+  return isNaN(n) ? 0 : n;
+}
+
+function fmtEuro_(v) {
+  const n = toNum_(v);
+  if (!n) {
+    return '';
+  }
+  return Utilities.formatString('%s €', n.toLocaleString('fr-FR', { minimumFractionDigits: 2, maximumFractionDigits: 2 }));
 }
 
 /* ======================= DIAG SERVER: wrappers de log ======================= */
-function _logHit(name, extra){ console.log('[HIT]', name, extra||''); }
+function _logHit(name, extra) {
+  console.log('[HIT]', name, extra || '');
+}
 
 try {
   if (typeof ui_getStockAll === 'function') {
-    var _ui_getStockAll = ui_getStockAll;
-    ui_getStockAll = function(){
+    const _ui_getStockAll = ui_getStockAll;
+    ui_getStockAll = function () {
       _logHit('ui_getStockAll');
       return _ui_getStockAll.apply(this, arguments);
     };
   }
-} catch(e){ console.warn('wrapper ui_getStockAll failed', e); }
+} catch (err) {
+  console.warn('wrapper ui_getStockAll failed', err);
+}
 
 try {
   if (typeof ui_getVentesAll === 'function') {
-    var _ui_getVentesAll = ui_getVentesAll;
-    ui_getVentesAll = function(){
+    const _ui_getVentesAll = ui_getVentesAll;
+    ui_getVentesAll = function () {
       _logHit('ui_getVentesAll');
       return _ui_getVentesAll.apply(this, arguments);
     };
   }
-} catch(e){ console.warn('wrapper ui_getVentesAll failed', e); }
+} catch (err) {
+  console.warn('wrapper ui_getVentesAll failed', err);
+}
 
 try {
   if (typeof ui_getDashboard === 'function') {
-    var _ui_getDashboard = ui_getDashboard;
-    ui_getDashboard = function(){
+    const _ui_getDashboard = ui_getDashboard;
+    ui_getDashboard = function () {
       _logHit('ui_getDashboard');
       return _ui_getDashboard.apply(this, arguments);
     };
   }
-} catch(e){ console.warn('wrapper ui_getDashboard failed', e); }
+} catch (err) {
+  console.warn('wrapper ui_getDashboard failed', err);
+}
 
 try {
   if (typeof ui_getLogsTail === 'function') {
-    var _ui_getLogsTail = ui_getLogsTail;
-    ui_getLogsTail = function(n){
-      _logHit('ui_getLogsTail', 'n='+n);
+    const _ui_getLogsTail = ui_getLogsTail;
+    ui_getLogsTail = function (n) {
+      _logHit('ui_getLogsTail', 'n=' + n);
       return _ui_getLogsTail.apply(this, arguments);
     };
   }
-} catch(e){ console.warn('wrapper ui_getLogsTail failed', e); }
+} catch (err) {
+  console.warn('wrapper ui_getLogsTail failed', err);
+}

--- a/Ui_Config.gs
+++ b/Ui_Config.gs
@@ -6,20 +6,36 @@
  * Effets de bord: ouvre un modal Sheets, lit/écrit l'onglet Configuration ligne par ligne.
  * Pièges: duplications en fin de fichier (fonctions répétées), attention aux locales (trim/uppercase), éviter insertSheet multiple.
  * MAJ: 2025-09-26 – Codex Audit
+ * @change: supprimé les doublons de fonctions et harmonisé les écritures.
  */
-// ==============================
-// FICHIER 2/4 — Ui_Config.gs (Apps Script, serveur)
-// ==============================
-/** Ouvre la fenêtre de configuration (popup) */
-function openConfigUI(){
+const UI_CONFIG_SHEET_NAME = 'Configuration';
+const UI_CONFIG_HEADERS = ['Clé', 'Valeur'];
+
+/**
+ * Ouvre la fenêtre de configuration (popup Sheets modal).
+ * @return {void}
+ */
+function openConfigUI() {
   const html = HtmlService.createHtmlOutputFromFile('ui_config')
     .setWidth(520)
     .setHeight(640);
   SpreadsheetApp.getUi().showModalDialog(html, 'Configuration du CRM');
 }
 
-/** Lit toutes les paires clé/valeur (upsert-friendly) */
-function getKnownConfig(){
+/**
+ * Inclut un fichier HTML (CSS/JS) et renvoie son contenu.
+ * @param {string} filename
+ * @return {string}
+ */
+function include_(filename) {
+  return HtmlService.createHtmlOutputFromFile(filename).getContent();
+}
+
+/**
+ * Renvoie la liste des clés connues avec leurs valeurs actuelles.
+ * @return {Array<{key:string,value:*}>}
+ */
+function getKnownConfig() {
   const knownKeys = [
     // Labels Gmail
     'GMAIL_LABEL_INGEST_STOCK',
@@ -32,110 +48,91 @@ function getKnownConfig(){
     'GMAIL_LABEL_OFFERS_VINTED',
     'GMAIL_LABEL_PURCHASES_VINTED',
     // Commissions par plateforme
-    'COMM_VINTED_PCT','COMM_VINTED_MIN','COMM_VINTED_FLAT',
-    'COMM_VESTIAIRE_PCT','COMM_VESTIAIRE_MIN','COMM_VESTIAIRE_FLAT',
-    'COMM_EBAY_PCT','COMM_EBAY_MIN','COMM_EBAY_FLAT',
-    'COMM_LEBONCOIN_PCT','COMM_LEBONCOIN_MIN','COMM_LEBONCOIN_FLAT',
-    'COMM_WHATNOT_PCT','COMM_WHATNOT_MIN','COMM_WHATNOT_FLAT',
+    'COMM_VINTED_PCT', 'COMM_VINTED_MIN', 'COMM_VINTED_FLAT',
+    'COMM_VESTIAIRE_PCT', 'COMM_VESTIAIRE_MIN', 'COMM_VESTIAIRE_FLAT',
+    'COMM_EBAY_PCT', 'COMM_EBAY_MIN', 'COMM_EBAY_FLAT',
+    'COMM_LEBONCOIN_PCT', 'COMM_LEBONCOIN_MIN', 'COMM_LEBONCOIN_FLAT',
+    'COMM_WHATNOT_PCT', 'COMM_WHATNOT_MIN', 'COMM_WHATNOT_FLAT',
     // Flags globaux
-    'APPLY_URSSAF','URSSAF_RATE',
-    'APPLY_FIXED_COSTS','FIXED_COST_PER_SALE',
+    'APPLY_URSSAF', 'URSSAF_RATE',
+    'APPLY_FIXED_COSTS', 'FIXED_COST_PER_SALE',
     'ROUND_MARGINS'
   ];
-  const map = getConfig_ ? getConfig_() : {};
-  return knownKeys.map(k => ({ key:k, value: (k in map? map[k] : '') }));
+
+  const map = typeof getConfig_ === 'function' ? getConfig_() : {};
+  return knownKeys.map(key => ({ key, value: Object.prototype.hasOwnProperty.call(map, key) ? map[key] : '' }));
 }
 
-/** Sauvegarde des valeurs (upsert dans l'onglet Configuration) */
-function saveConfigValues(rows){
-  // rows: [{key, value}]
-  const ss = SpreadsheetApp.getActive();
-  const name = 'Configuration';
-  const sh = ss.getSheetByName(name) || ss.insertSheet(name);
-  // En-têtes si besoin
-  if (sh.getLastRow() === 0){
-    sh.getRange(1,1,1,2).setValues([["Clé","Valeur"]]).setFontWeight('bold');
-    sh.setFrozenRows(1);
+/**
+ * Sauvegarde des paires clé/valeur dans l'onglet Configuration.
+ * @param {Array<{key:string,value:*}>} rows
+ * @return {{ok:boolean,count:number}}
+ */
+function saveConfigValues(rows) {
+  const cleaned = Array.isArray(rows) ? rows.filter(r => r && String(r.key || '').trim()) : [];
+  if (!cleaned.length) {
+    return { ok: true, count: 0 };
   }
-  // Index existant par clé
-  const last = sh.getLastRow();
-  const idx = {};
-  if (last >= 2){
-    const keys = sh.getRange(2,1,last-1,1).getValues();
-    for (let i=0;i<keys.length;i++){
-      const k = String(keys[i][0]||'').trim();
-      if (k) idx[k] = i+2; // row
+
+  const sheet = ensureConfigSheet_();
+  const index = buildConfigIndex_(sheet);
+  const writes = [];
+  let nextRow = Math.max(2, sheet.getLastRow() + 1);
+
+  cleaned.forEach(item => {
+    const key = String(item.key).trim();
+    const value = item.value;
+    let row = index[key];
+    if (!row) {
+      row = nextRow;
+      index[key] = row;
+      nextRow += 1;
+    }
+    writes.push({ row, values: [key, value] });
+  });
+
+  if (writes.length) {
+    writes.sort((a, b) => a.row - b.row);
+    writes.forEach(({ row, values }) => {
+      sheet.getRange(row, 1, 1, values.length).setValues([values]);
+    });
+  }
+
+  return { ok: true, count: cleaned.length };
+}
+
+/**
+ * S'assure que l'onglet Configuration existe avec les en-têtes.
+ * @return {GoogleAppsScript.Spreadsheet.Sheet}
+ */
+function ensureConfigSheet_() {
+  const ss = SpreadsheetApp.getActive();
+  const sheet = ss.getSheetByName(UI_CONFIG_SHEET_NAME) || ss.insertSheet(UI_CONFIG_SHEET_NAME);
+  if (sheet.getLastRow() === 0) {
+    sheet.getRange(1, 1, 1, UI_CONFIG_HEADERS.length)
+      .setValues([UI_CONFIG_HEADERS])
+      .setFontWeight('bold');
+    sheet.setFrozenRows(1);
+  }
+  return sheet;
+}
+
+/**
+ * Construit un index clé -> numéro de ligne.
+ * @param {GoogleAppsScript.Spreadsheet.Sheet} sheet
+ * @return {Object<string,number>}
+ */
+function buildConfigIndex_(sheet) {
+  const index = {};
+  const last = sheet.getLastRow();
+  if (last >= 2) {
+    const keys = sheet.getRange(2, 1, last - 1, 1).getValues();
+    for (let i = 0; i < keys.length; i++) {
+      const key = String(keys[i][0] || '').trim();
+      if (key) {
+        index[key] = i + 2;
+      }
     }
   }
-  // Upsert ligne par ligne
-  rows.forEach(r => {
-    const k = String(r.key||'').trim();
-    if (!k) return;
-    const v = r.value;
-    let row = idx[k];
-    if (!row){ row = Math.max(2, sh.getLastRow()+1); idx[k] = row; }
-    sh.getRange(row,1).setValue(k);
-    sh.getRange(row,2).setValue(v);
-  });
-  return {ok:true, count: rows.length};
-
-/** Ouvre la fenêtre de configuration (popup) */
-function openConfigUI(){
-  const html = HtmlService.createHtmlOutputFromFile('ui_config')
-    .setWidth(520)
-    .setHeight(640);
-  SpreadsheetApp.getUi().showModalDialog(html, 'Configuration du CRM');
-}
-
-/** Inclut un fichier HTML (CSS/JS) et renvoie son contenu */
-function include_(filename){
-  return HtmlService.createHtmlOutputFromFile(filename).getContent();
-}
-
-/** Renvoie les paires clé/valeur existantes (déjà fourni plus tôt) */
-function getKnownConfig(){
-  const knownKeys = [
-    'GMAIL_LABEL_INGEST_STOCK','GMAIL_LABEL_SALES_VINTED','GMAIL_LABEL_SALES_VESTIAIRE',
-    'GMAIL_LABEL_SALES_EBAY','GMAIL_LABEL_SALES_LEBONCOIN','GMAIL_LABEL_SALES_WHATNOT',
-    'GMAIL_LABEL_FAVORITES_VINTED','GMAIL_LABEL_OFFERS_VINTED','GMAIL_LABEL_PURCHASES_VINTED',
-    'COMM_VINTED_PCT','COMM_VINTED_MIN','COMM_VINTED_FLAT',
-    'COMM_VESTIAIRE_PCT','COMM_VESTIAIRE_MIN','COMM_VESTIAIRE_FLAT',
-    'COMM_EBAY_PCT','COMM_EBAY_MIN','COMM_EBAY_FLAT',
-    'COMM_LEBONCOIN_PCT','COMM_LEBONCOIN_MIN','COMM_LEBONCOIN_FLAT',
-    'COMM_WHATNOT_PCT','COMM_WHATNOT_MIN','COMM_WHATNOT_FLAT',
-    'APPLY_URSSAF','URSSAF_RATE','APPLY_FIXED_COSTS','FIXED_COST_PER_SALE','ROUND_MARGINS'
-  ];
-  const map = (typeof getConfig_ === 'function') ? getConfig_() : {};
-  return knownKeys.map(k => ({ key:k, value: (k in map ? map[k] : '') }));
-}
-
-/** Upsert dans l’onglet Configuration (déjà fourni plus tôt) */
-function saveConfigValues(rows){
-  const ss = SpreadsheetApp.getActive();
-  const sh = ss.getSheetByName('Configuration') || ss.insertSheet('Configuration');
-  if (sh.getLastRow() === 0){
-    sh.getRange(1,1,1,2).setValues([['Clé','Valeur']]).setFontWeight('bold');
-    sh.setFrozenRows(1);
-  }
-  const last = sh.getLastRow();
-  const idx = {};
-  if (last >= 2){
-    const keys = sh.getRange(2,1,last-1,1).getValues();
-    for (let i=0;i<keys.length;i++){
-      const k = String(keys[i][0]||'').trim();
-      if (k) idx[k] = i+2;
-    }
-  }
-  rows.forEach(r => {
-    const k = String(r.key||'').trim(); if (!k) return;
-    const v = r.value;
-    let row = idx[k];
-    if (!row){ row = Math.max(2, sh.getLastRow()+1); idx[k] = row; }
-    sh.getRange(row,1).setValue(k);
-    sh.getRange(row,2).setValue(v);
-  });
-  return {ok:true, count: rows.length};
-}
-
-
+  return index;
 }


### PR DESCRIPTION
## Summary
- remove duplicate Ui_Config helpers and expose cache-aware endpoints from PerfendPoints while retiring Ui_Server logic
- wrap Gmail ingestion, backup, and PDF generation network calls with a shared withBackoff_ helper and batch sheet writes for faster ingestion
- sanitize CRM HTML templates, add targeted Dashboard rebuild without sheet.clear, and tighten configuration validation including bounded commissions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d673fd531083219851ba805e9d1a4f